### PR TITLE
Fix guide links on homepage

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -51,7 +51,7 @@ $ cd my-api &amp;&amp; denali serve</code>
           on APIs first. First class support for
           <a href="latest/guides/data/serializers/">JSON serializers</a>,
           <a href="latest/guides/application/routing">RESTful routing</a>,
-          and <a href="denali/latest/guides/testing/integration">powerful testing helpers</a>
+          and <a href="latest/guides/testing/integration">powerful testing helpers</a>
           make building APIs easier than ever.
         </p>
       </div>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -49,9 +49,9 @@ $ cd my-api &amp;&amp; denali serve</code>
           You won't find any templating languages, views, or other HTML
           rendering support out of the box. Denali is unapologetically focused
           on APIs first. First class support for
-          <a href="latest/guides/serializers">JSON serializers</a>,
-          <a href="latest/guides/routing">RESTful routing</a>,
-          and <a href="latest/guides/integration">powerful testing helpers</a>
+          <a href="denali/latest/guides/serializers">JSON serializers</a>,
+          <a href="denali/latest/guides/routing">RESTful routing</a>,
+          and <a href="denali/latest/guides/integration">powerful testing helpers</a>
           make building APIs easier than ever.
         </p>
       </div>
@@ -65,11 +65,11 @@ $ cd my-api &amp;&amp; denali serve</code>
         <h2>Developer happiness</h2>
         <p class="feature-description">
           Denali ships with a top-notch CLI which can run
-          <a href="latest/guides/server">reload-on-change development server</a>,
-          <a href="latest/guides/generate">scaffold new code</a>,
-          <a href="latest/guides/test">run tests</a>, and more. Extensibility
+          <a href="denali/latest/guides/server">reload-on-change development server</a>,
+          <a href="denali/latest/guides/generate">scaffold new code</a>,
+          <a href="denali/latest/guides/test">run tests</a>, and more. Extensibility
           is baked into the core as well, with
-          <a href="latest/guides/addons">Addons</a> providing a powerful
+          <a href="denali/latest/guides/addons">Addons</a> providing a powerful
           approach to incorporating third party code.
         </p>
       </div>
@@ -82,8 +82,8 @@ $ cd my-api &amp;&amp; denali serve</code>
       <div class='col-md-6'>
         <h2>Data Flexibility</h2>
         <p class="feature-description">
-          Thanks to it's unique <a href="latest/guides/models">model</a> +
-          <a href="latest/guides/orm-adapters">adapter</a> approach, Denali
+          Thanks to it's unique <a href="denali/latest/guides/models">model</a> +
+          <a href="denali/latest/guides/orm-adapters">adapter</a> approach, Denali
           let's you use whatever ORM you want with it. And Denali Addons will
           work with it out of the box. You can even use multiple ORMs in the
           same project to fully leverage the strengths of each data store
@@ -94,7 +94,7 @@ $ cd my-api &amp;&amp; denali serve</code>
 
     <div class="cta">
       <h2 class="cta-header">Sound Interesting?</h2>
-      <a class='cta-btn' href='latest/guides/introduction'>
+      <a class='cta-btn' href='denali/latest/guides/introduction'>
         Check out the Guides
       </a>
     </div>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -49,9 +49,9 @@ $ cd my-api &amp;&amp; denali serve</code>
           You won't find any templating languages, views, or other HTML
           rendering support out of the box. Denali is unapologetically focused
           on APIs first. First class support for
-          <a href="denali/latest/guides/serializers">JSON serializers</a>,
-          <a href="denali/latest/guides/routing">RESTful routing</a>,
-          and <a href="denali/latest/guides/integration">powerful testing helpers</a>
+          <a href="latest/guides/data/serializers/">JSON serializers</a>,
+          <a href="latest/guides/application/routing">RESTful routing</a>,
+          and <a href="denali/latest/guides/testing/integration">powerful testing helpers</a>
           make building APIs easier than ever.
         </p>
       </div>
@@ -65,11 +65,11 @@ $ cd my-api &amp;&amp; denali serve</code>
         <h2>Developer happiness</h2>
         <p class="feature-description">
           Denali ships with a top-notch CLI which can run
-          <a href="denali/latest/guides/server">reload-on-change development server</a>,
-          <a href="denali/latest/guides/generate">scaffold new code</a>,
-          <a href="denali/latest/guides/test">run tests</a>, and more. Extensibility
+          <a href="latest/guides/cli/serve">reload-on-change development server</a>,
+          <a href="latest/guides/cli/generate">scaffold new code</a>,
+          <a href="latest/guides/cli/test">run tests</a>, and more. Extensibility
           is baked into the core as well, with
-          <a href="denali/latest/guides/addons">Addons</a> providing a powerful
+          <a href="latest/guides/cli/addon">Addons</a> providing a powerful
           approach to incorporating third party code.
         </p>
       </div>
@@ -82,8 +82,8 @@ $ cd my-api &amp;&amp; denali serve</code>
       <div class='col-md-6'>
         <h2>Data Flexibility</h2>
         <p class="feature-description">
-          Thanks to it's unique <a href="denali/latest/guides/models">model</a> +
-          <a href="denali/latest/guides/orm-adapters">adapter</a> approach, Denali
+          Thanks to it's unique <a href="latest/guides/data/models">model</a> +
+          <a href="latest/guides/data/orm-adapters">adapter</a> approach, Denali
           let's you use whatever ORM you want with it. And Denali Addons will
           work with it out of the box. You can even use multiple ORMs in the
           same project to fully leverage the strengths of each data store
@@ -94,7 +94,7 @@ $ cd my-api &amp;&amp; denali serve</code>
 
     <div class="cta">
       <h2 class="cta-header">Sound Interesting?</h2>
-      <a class='cta-btn' href='denali/latest/guides/introduction'>
+      <a class='cta-btn' href='latest/guides/overview/introduction'>
         Check out the Guides
       </a>
     </div>


### PR DESCRIPTION
All of the links to the guides were broken