### PR TITLE
Update files that are packaged

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "davewasmer.com"
   },
   "files": [
-    "dist",
-    "bin"
+    "bin",
+    "lib"
   ],
   "bin": {
     "denali": "bin/denali"


### PR DESCRIPTION
The dist folder doesn't exist, but we **do** need the lib folder in order for this to work if it's been installed via npm (instead of via a linkage) 😀 