### PR TITLE
feat(cli): Addon Blueprints

### DIFF
--- a/lib/cli/commands/addon.js
+++ b/lib/cli/commands/addon.js
@@ -22,11 +22,7 @@ http://denalijs.github.com/denali/guides/addons
 
   allowExtraArgs = true;
 
-  run(args, argTokens) {
-    console.log(args);
-    let project = new Project({
-      environment: args.environment
-    });
+  run(args, argTokens, project) {
     project.createApplication().then((application) => {
       let blueprint = application.getBlueprint('addon');
       blueprint.generate(this.parseArgs.call(blueprint, argTokens));

--- a/lib/cli/commands/addon.js
+++ b/lib/cli/commands/addon.js
@@ -1,5 +1,5 @@
 import Command from '../lib/command';
-import AddonBlueprint from '../blueprints/addon';
+import Project from '../lib/project';
 
 export default class AddonCommand extends Command {
 
@@ -23,8 +23,13 @@ http://denalijs.github.com/denali/guides/addons
   allowExtraArgs = true;
 
   run(args, argTokens) {
-    let blueprint = new AddonBlueprint();
-    blueprint.generate(this.parseArgs.call(blueprint, argTokens));
+    let project = new Project({
+      environment: args.environment
+    });
+    project.createApplication().then((application) => {
+      let blueprint = application.getBlueprint('addon');
+      blueprint.generate(this.parseArgs.call(blueprint, argTokens));
+    });
   }
 
 }

--- a/lib/cli/commands/addon.js
+++ b/lib/cli/commands/addon.js
@@ -23,6 +23,7 @@ http://denalijs.github.com/denali/guides/addons
   allowExtraArgs = true;
 
   run(args, argTokens) {
+    console.log(args);
     let project = new Project({
       environment: args.environment
     });

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -11,7 +11,7 @@ import find from 'lodash/find';
 class Addon {
   constructor(name, addonPath) {
     this.name = name;
-    this.path = addonPath;
+    this.path = path.join(addonPath, '..');
   }
 
   get blueprintNames() {

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -44,23 +44,40 @@ addons).
   }
 
   findBlueprint(name) {
+    const split = name.split(':');
+    const hasNamespace = split.length > 1;
+    const namespace = hasNamespace ? split[0] : undefined;
+    const blueprintName = hasNamespace ? split.slice(1).join(':') : split[0];
     const addons = discoverAddons(process.cwd());
     const sorted = topsort(addons);
     const blueprints = sorted.map((details) => {
       try {
         return {
-          addon: details.name,
-          blueprint: require(path.join(details.dir, 'blueprints', name)).default
+          namespace: details.name,
+          blueprint: require(path.join(details.dir, 'blueprints', blueprintName)).default
         };
       } catch (e) {
         return false;
       }
-    }).filter((blueprint) => Boolean(blueprint));
+    }).filter((blueprint) => {
+      let allow = true;
+
+      // Only allow namespaced blueprint
+      if (namespace) {
+        allow = blueprint.namespace === namespace;
+      }
+
+      return Boolean(blueprint) && allow;
+    });
 
     // Add local cli blueprint if it exists
     try {
-      let localBlueprint = require(`../blueprints/${ name }`).default;
-      blueprints.unshift({ blueprint: localBlueprint });
+      let localBlueprint = require(`../blueprints/${ blueprintName }`).default;
+
+      blueprints.unshift({
+        namespace: 'denali',
+        blueprint: localBlueprint
+      });
     } catch (e) {
       // noop
     }

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -84,12 +84,12 @@ addons).
   }
 
   findBlueprint(name) {
-    const split = name.split(':');
-    const hasNamespace = split.length > 1;
-    const namespace = hasNamespace ? split[0] : undefined;
-    const blueprintName = hasNamespace ? split.slice(1).join(':') : split[0];
-    const addonData = discoverAddons(process.cwd());
-    const addons = topsort(addonData).map((data) => {
+    let split = name.split(':');
+    let hasNamespace = split.length > 1;
+    let namespace = hasNamespace ? split[0] : undefined;
+    let blueprintName = hasNamespace ? split.slice(1).join(':') : split[0];
+    let addonData = discoverAddons(process.cwd());
+    let addons = topsort(addonData).map((data) => {
       return new Addon(data.name, data.dir);
     });
     let blueprints = addons.reduce((all, addon) => {
@@ -120,16 +120,16 @@ addons).
       // noop
     }
 
-    return hasNamespace ? find(blueprints, 'namespace', namespace) : blueprints.slice(-1)[0];
+    return hasNamespace ? find(blueprints, 'namespace', namespace) : blueprints.pop();
   }
 
   printHelp() {
     super.printHelp();
-    const addons = discoverAddons(process.cwd());
+    let addons = discoverAddons(process.cwd());
 
-    if (addons.length) {
+    if (addons.length > 0) {
       ui.info('Addon Blueprints:');
-      const sorted = topsort(addons).map((data) => {
+      let sorted = topsort(addons).map((data) => {
         return new Addon(data.name, data.dir);
       });
       sorted.forEach((addon) => {

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -5,6 +5,7 @@ import Command from '../lib/command';
 import discoverAddons from '../../utils/discover-addons';
 import topsort from '../../utils/topsort';
 import padEnd from 'lodash/padEnd';
+import find from 'lodash/find';
 
 export default class GenerateCommand extends Command {
 
@@ -36,10 +37,7 @@ addons).
     const result = this.findBlueprint(blueprintName);
 
     if (result) {
-      let Blueprint = result.blueprint;
-      let blueprint = new Blueprint({
-        dir: result.path
-      });
+      let blueprint = result.instance;
       let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
       blueprint.generate(blueprintArgs);
     } else {
@@ -52,29 +50,20 @@ addons).
     const hasNamespace = split.length > 1;
     const namespace = hasNamespace ? split[0] : undefined;
     const blueprintName = hasNamespace ? split.slice(1).join(':') : split[0];
-    const addons = discoverAddons(process.cwd());
-    const sorted = topsort(addons);
-    const blueprints = sorted.map((details) => {
-      try {
-        let blueprintPath = path.join(details.dir, 'blueprints', blueprintName);
-        return {
-          namespace: details.name,
-          path: blueprintPath,
-          blueprint: require(blueprintPath).default
-        };
-      } catch (e) {
-        return false;
-      }
-    }).filter((blueprint) => {
-      let allow = true;
-
-      // Only allow namespaced blueprint
-      if (namespace) {
-        allow = blueprint.namespace === namespace;
-      }
-
-      return Boolean(blueprint) && allow;
+    const addonData = discoverAddons(process.cwd());
+    const addons = topsort(addonData).map((data) => {
+      return new Addon(data.name, data.dir);
     });
+    let blueprints = addons.reduce((all, addon) => {
+      if (addon.hasBlueprint(blueprintName)) {
+        let blueprint = addon.getBlueprint(blueprintName);
+        if (blueprint) {
+          all.push(blueprint);
+        }
+      }
+
+      return all;
+    }, []);
 
     // Add local cli blueprint if it exists
     try {
@@ -84,19 +73,38 @@ addons).
       blueprints.unshift({
         namespace: 'denali',
         path: basePath,
-        blueprint: localBlueprint
+        instance: localBlueprint
       });
     } catch (e) {
       // noop
     }
 
-    // Return last blueprint matched
-    return blueprints.slice(-1)[0];
+    return hasNamespace ? find(blueprints, 'namespace', namespace) : blueprints.slice(-1)[0];
   }
 
   printHelp() {
     super.printHelp();
-    ui.info('Available Blueprints:');
+    const addons = discoverAddons(process.cwd());
+
+    if (addons.length) {
+      ui.info('Addon Blueprints:');
+      const sorted = topsort(addons).map((data) => {
+        return new Addon(data.name, data.dir);
+      });
+      sorted.forEach((addon) => {
+        let blueprints = addon.blueprints;
+        let pad = blueprints.reduce((length, item) => Math.max(length, item.name.length), 0);
+        ui.info(`  ${ addon.name }:`);
+        blueprints.forEach((blueprint) => {
+          let impl = blueprint.load();
+          ui.info(`    ${ padEnd(blueprint.name, pad) }  ${ impl.description || '' }`);
+        });
+      });
+      ui.info('\n');
+    }
+
+
+    ui.info('Denali Blueprints:');
     let blueprints = fs.readdirSync(path.join(__dirname, '..', 'blueprints'));
     let pad = blueprints.reduce((length, name) => Math.max(length, name.length), 0);
 
@@ -106,4 +114,62 @@ addons).
     });
   }
 
+}
+
+class Addon {
+  constructor(name, path) {
+    this.name = name;
+    this.path = path;
+  }
+
+  get blueprintNames() {
+    let names = fs.readdirSync(path.join(this.path, 'blueprints'));
+    return names;
+  }
+
+  get blueprints() {
+    return this.blueprintNames.map((name) => {
+      return new Blueprint(name, this);
+    });
+  }
+
+  hasBlueprint(name) {
+    const names = this.blueprintNames;
+    const blueprint = names.includes(name);
+
+    return !!blueprint;
+  }
+
+  getBlueprint(name) {
+    try {
+      return new Blueprint(name, this);
+    } catch (e) {
+      // noop
+    }
+  }
+}
+
+class Blueprint {
+  constructor(name, addon) {
+    this.name = name;
+    this.addon = addon;
+  }
+
+  get instance() {
+    let Print = require(this.path).default;
+
+    if (Print) {
+      return new Print({
+        dir: this.path
+      });
+    }
+  }
+
+  get path() {
+    return path.join(this.addon.path, 'blueprints', this.name);
+  }
+
+  get namespace() {
+    return this.addon.name;
+  }
 }

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -7,43 +7,6 @@ import topsort from '../../utils/topsort';
 import padEnd from 'lodash/padEnd';
 import find from 'lodash/find';
 
-// TODO merge this with lib/runtime/addon.js
-class Addon {
-  constructor(name, addonPath) {
-    this.name = name;
-    this.path = path.join(addonPath, '..');
-  }
-
-  get blueprintNames() {
-    let names = fs.readdirSync(path.join(this.path, 'blueprints'));
-    return names;
-  }
-
-  get blueprints() {
-    return this.blueprintNames.map((name) => {
-      let blueprintPath = path.join(this.path, 'blueprints', name);
-      let Print = require(blueprintPath).default;
-      return new Print({ name, addon: this, description: Print.description });
-    });
-  }
-
-  hasBlueprint(name) {
-    const names = this.blueprintNames;
-    const blueprint = names.includes(name);
-
-    return Boolean(blueprint);
-  }
-
-  getBlueprint(name) {
-    try {
-      let blueprintPath = path.join(this.path, 'blueprints', name);
-      let Print = require(blueprintPath).default;
-      return new Print({ name, addon: this });
-    } catch (e) {
-      // noop
-    }
-  }
-}
 
 export default class GenerateCommand extends Command {
 
@@ -72,10 +35,9 @@ addons).
   }
 
   generateBlueprint(blueprintName, argTokens) {
-    const result = this.findBlueprint(blueprintName);
+    const blueprint = this.findBlueprint(blueprintName);
 
-    if (result) {
-      let blueprint = result.instance;
+    if (blueprint) {
       let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
       blueprint.generate(blueprintArgs);
     } else {
@@ -90,7 +52,12 @@ addons).
     let blueprintName = hasNamespace ? split.slice(1).join(':') : split[0];
     let addonData = discoverAddons(process.cwd());
     let addons = topsort(addonData).map((data) => {
-      return new Addon(data.name, data.dir);
+      let addonPath = path.join(data.dir, 'app', 'addon.js');
+      let Addon = require(addonPath).default;
+
+      return new Addon({
+        dir: data.dir
+      });
     });
     let blueprints = addons.reduce((all, addon) => {
       if (addon.hasBlueprint(blueprintName)) {
@@ -112,7 +79,7 @@ addons).
         name: blueprintName,
         addon: {
           name: 'denali',
-          path: '../'
+          dir: '../'
         },
         description: LocalBlueprint.description
       }));
@@ -125,14 +92,19 @@ addons).
 
   printHelp() {
     super.printHelp();
-    let addons = discoverAddons(process.cwd());
+    let addonData = discoverAddons(process.cwd());
 
-    if (addons.length > 0) {
+    if (addonData.length > 0) {
       ui.info('Addon Blueprints:');
-      let sorted = topsort(addons).map((data) => {
-        return new Addon(data.name, data.dir);
+      let addons = topsort(addonData).map((data) => {
+        let addonPath = path.join(data.dir, 'app', 'addon.js');
+        let Addon = require(addonPath).default;
+
+        return new Addon({
+          dir: data.dir
+        });
       });
-      sorted.forEach((addon) => {
+      addons.forEach((addon) => {
         let blueprints = addon.blueprints;
         let pad = blueprints.reduce((length, item) => Math.max(length, item.name.length), 0);
         ui.info(`  ${ addon.name }:`);

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -96,7 +96,7 @@ addons).
         let pad = blueprints.reduce((length, item) => Math.max(length, item.name.length), 0);
         ui.info(`  ${ addon.name }:`);
         blueprints.forEach((blueprint) => {
-          let impl = blueprint.load();
+          let impl = blueprint.instance;
           ui.info(`    ${ padEnd(blueprint.name, pad) }  ${ impl.description || '' }`);
         });
       });
@@ -109,8 +109,8 @@ addons).
     let pad = blueprints.reduce((length, name) => Math.max(length, name.length), 0);
 
     blueprints.forEach((blueprintName) => {
-      const Blueprint = this.findBlueprint(blueprintName).blueprint;
-      ui.info(`  ${ padEnd(blueprintName, pad) }  ${ Blueprint.description }`);
+      const blueprint = this.findBlueprint(blueprintName).instance;
+      ui.info(`  ${ padEnd(blueprintName, pad) }  ${ blueprint.description }`);
     });
   }
 

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -68,13 +68,16 @@ addons).
     // Add local cli blueprint if it exists
     try {
       let basePath = `../blueprints/${ blueprintName }`;
-      let localBlueprint = require(basePath).default;
+      let LocalBlueprint = require(basePath).default;
 
-      blueprints.unshift({
-        namespace: 'denali',
-        path: basePath,
-        instance: localBlueprint
-      });
+      blueprints.unshift(new LocalBlueprint({
+        name: blueprintName,
+        addon: {
+          name: 'denali',
+          path: '../'
+        },
+        description: LocalBlueprint.description
+      }));
     } catch (e) {
       // noop
     }
@@ -96,8 +99,7 @@ addons).
         let pad = blueprints.reduce((length, item) => Math.max(length, item.name.length), 0);
         ui.info(`  ${ addon.name }:`);
         blueprints.forEach((blueprint) => {
-          let impl = blueprint.instance;
-          ui.info(`    ${ padEnd(blueprint.name, pad) }  ${ impl.description || '' }`);
+          ui.info(`    ${ padEnd(blueprint.name, pad) }  ${ blueprint.description || '' }`);
         });
       });
       ui.info('\n');
@@ -109,7 +111,7 @@ addons).
     let pad = blueprints.reduce((length, name) => Math.max(length, name.length), 0);
 
     blueprints.forEach((blueprintName) => {
-      const blueprint = this.findBlueprint(blueprintName).instance;
+      const blueprint = this.findBlueprint(blueprintName);
       ui.info(`  ${ padEnd(blueprintName, pad) }  ${ blueprint.description }`);
     });
   }
@@ -129,7 +131,9 @@ class Addon {
 
   get blueprints() {
     return this.blueprintNames.map((name) => {
-      return new Blueprint(name, this);
+      let blueprintPath = path.join(this.path, 'blueprints', name);
+      let Print = require(blueprintPath).default;
+      return new Print({ name, addon: this, description: Print.description });
     });
   }
 
@@ -142,34 +146,11 @@ class Addon {
 
   getBlueprint(name) {
     try {
-      return new Blueprint(name, this);
+      let blueprintPath = path.join(this.path, 'blueprints', name);
+      let Print = require(blueprintPath).default;
+      return new Print({ name, addon: this });
     } catch (e) {
       // noop
     }
-  }
-}
-
-class Blueprint {
-  constructor(name, addon) {
-    this.name = name;
-    this.addon = addon;
-  }
-
-  get instance() {
-    let Print = require(this.path).default;
-
-    if (Print) {
-      return new Print({
-        dir: this.path
-      });
-    }
-  }
-
-  get path() {
-    return path.join(this.addon.path, 'blueprints', this.name);
-  }
-
-  get namespace() {
-    return this.addon.name;
   }
 }

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -55,13 +55,15 @@ addons).
       } catch (e) {
         return false;
       }
-    }).filter((blueprint) => !!blueprint);
+    }).filter((blueprint) => Boolean(blueprint));
 
     // Add local cli blueprint if it exists
     try {
       let localBlueprint = require(`../blueprints/${ name }`).default;
       blueprints.unshift({ blueprint: localBlueprint });
-    } catch (e) {}
+    } catch (e) {
+      // noop
+    }
 
     // Return last blueprint matched
     return blueprints.slice(-1);

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import ui from '../lib/ui';
 import Command from '../lib/command';
+import discoverAddons from '../../utils/discover-addons';
+import topsort from '../../utils/topsort';
 import padEnd from 'lodash/padEnd';
 
 export default class GenerateCommand extends Command {
@@ -32,7 +34,7 @@ addons).
 
   generateBlueprint(blueprintName, argTokens) {
     try {
-      const Blueprint = this.findBlueprint(blueprintName);
+      const Blueprint = this.findBlueprint(blueprintName).blueprint;
       let blueprint = new Blueprint();
       let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
       blueprint.generate(blueprintArgs);
@@ -42,7 +44,27 @@ addons).
   }
 
   findBlueprint(name) {
-    return require(`../blueprints/${ name }`).default;
+    const addons = discoverAddons(process.cwd());
+    const sorted = topsort(addons);
+    const blueprints = sorted.map((details) => {
+      try {
+        return {
+          addon: details.name,
+          blueprint: require(path.join(details.dir, 'blueprints', name)).default
+        };
+      } catch (e) {
+        return false;
+      }
+    }).filter((blueprint) => !!blueprint);
+
+    // Add local cli blueprint if it exists
+    try {
+      let localBlueprint = require(`../blueprints/${ name }`).default;
+      blueprints.unshift({ blueprint: localBlueprint });
+    } catch (e) {}
+
+    // Return last blueprint matched
+    return blueprints.slice(-1);
   }
 
   printHelp() {

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -33,12 +33,20 @@ addons).
   }
 
   generateBlueprint(blueprintName, argTokens) {
-    try {
-      const Blueprint = this.findBlueprint(blueprintName).blueprint;
-      let blueprint = new Blueprint();
-      let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
-      blueprint.generate(blueprintArgs);
-    } catch (e) {
+    const result = this.findBlueprint(blueprintName);
+
+    if (result) {
+      try {
+        let Blueprint = result.blueprint;
+        let blueprint = new Blueprint({
+          dir: result.path
+        });
+        let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
+        blueprint.generate(blueprintArgs);
+      } catch (e) {
+        debugger;
+      }
+    } else {
       ui.info(`Blueprint '${ blueprintName }' doesn't exist.`);
     }
   }
@@ -52,9 +60,11 @@ addons).
     const sorted = topsort(addons);
     const blueprints = sorted.map((details) => {
       try {
+        let blueprintPath = path.join(details.dir, 'blueprints', blueprintName);
         return {
           namespace: details.name,
-          blueprint: require(path.join(details.dir, 'blueprints', blueprintName)).default
+          path: blueprintPath,
+          blueprint: require(blueprintPath).default
         };
       } catch (e) {
         return false;
@@ -72,10 +82,12 @@ addons).
 
     // Add local cli blueprint if it exists
     try {
-      let localBlueprint = require(`../blueprints/${ blueprintName }`).default;
+      let basePath = `../blueprints/${ blueprintName }`;
+      let localBlueprint = require(basePath).default;
 
       blueprints.unshift({
         namespace: 'denali',
+        path: basePath,
         blueprint: localBlueprint
       });
     } catch (e) {
@@ -83,7 +95,7 @@ addons).
     }
 
     // Return last blueprint matched
-    return blueprints.slice(-1);
+    return blueprints.slice(-1)[0];
   }
 
   printHelp() {
@@ -93,7 +105,7 @@ addons).
     let pad = blueprints.reduce((length, name) => Math.max(length, name.length), 0);
 
     blueprints.forEach((blueprintName) => {
-      const Blueprint = this.findBlueprint(blueprintName);
+      const Blueprint = this.findBlueprint(blueprintName).blueprint;
       ui.info(`  ${ padEnd(blueprintName, pad) }  ${ Blueprint.description }`);
     });
   }

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -36,8 +36,8 @@ addons).
       let blueprint = new Blueprint();
       let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
       blueprint.generate(blueprintArgs);
-    } catch(e) {
-      ui.info(`Blueprint '${blueprintName}' doesn't exist.`);
+    } catch (e) {
+      ui.info(`Blueprint '${ blueprintName }' doesn't exist.`);
     }
   }
 

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -36,16 +36,12 @@ addons).
     const result = this.findBlueprint(blueprintName);
 
     if (result) {
-      try {
-        let Blueprint = result.blueprint;
-        let blueprint = new Blueprint({
-          dir: result.path
-        });
-        let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
-        blueprint.generate(blueprintArgs);
-      } catch (e) {
-        debugger;
-      }
+      let Blueprint = result.blueprint;
+      let blueprint = new Blueprint({
+        dir: result.path
+      });
+      let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
+      blueprint.generate(blueprintArgs);
     } else {
       ui.info(`Blueprint '${ blueprintName }' doesn't exist.`);
     }

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -31,10 +31,18 @@ addons).
   }
 
   generateBlueprint(blueprintName, argTokens) {
-    const Blueprint = require(`../blueprints/${ blueprintName }`).default;
-    let blueprint = new Blueprint();
-    let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
-    blueprint.generate(blueprintArgs);
+    try {
+      const Blueprint = this.findBlueprint(blueprintName);
+      let blueprint = new Blueprint();
+      let blueprintArgs = this.parseArgs.call(blueprint, argTokens.slice(1));
+      blueprint.generate(blueprintArgs);
+    } catch(e) {
+      ui.info(`Blueprint '${blueprintName}' doesn't exist.`);
+    }
+  }
+
+  findBlueprint(name) {
+    return require(`../blueprints/${ name }`).default;
   }
 
   printHelp() {
@@ -42,8 +50,9 @@ addons).
     ui.info('Available Blueprints:');
     let blueprints = fs.readdirSync(path.join(__dirname, '..', 'blueprints'));
     let pad = blueprints.reduce((length, name) => Math.max(length, name.length), 0);
+
     blueprints.forEach((blueprintName) => {
-      const Blueprint = require(`../blueprints/${ blueprintName }`).default;
+      const Blueprint = this.findBlueprint(blueprintName);
       ui.info(`  ${ padEnd(blueprintName, pad) }  ${ Blueprint.description }`);
     });
   }

--- a/lib/cli/commands/generate.js
+++ b/lib/cli/commands/generate.js
@@ -7,6 +7,44 @@ import topsort from '../../utils/topsort';
 import padEnd from 'lodash/padEnd';
 import find from 'lodash/find';
 
+// TODO merge this with lib/runtime/addon.js
+class Addon {
+  constructor(name, addonPath) {
+    this.name = name;
+    this.path = addonPath;
+  }
+
+  get blueprintNames() {
+    let names = fs.readdirSync(path.join(this.path, 'blueprints'));
+    return names;
+  }
+
+  get blueprints() {
+    return this.blueprintNames.map((name) => {
+      let blueprintPath = path.join(this.path, 'blueprints', name);
+      let Print = require(blueprintPath).default;
+      return new Print({ name, addon: this, description: Print.description });
+    });
+  }
+
+  hasBlueprint(name) {
+    const names = this.blueprintNames;
+    const blueprint = names.includes(name);
+
+    return Boolean(blueprint);
+  }
+
+  getBlueprint(name) {
+    try {
+      let blueprintPath = path.join(this.path, 'blueprints', name);
+      let Print = require(blueprintPath).default;
+      return new Print({ name, addon: this });
+    } catch (e) {
+      // noop
+    }
+  }
+}
+
 export default class GenerateCommand extends Command {
 
   static commandName = 'generate';
@@ -118,39 +156,3 @@ addons).
 
 }
 
-class Addon {
-  constructor(name, path) {
-    this.name = name;
-    this.path = path;
-  }
-
-  get blueprintNames() {
-    let names = fs.readdirSync(path.join(this.path, 'blueprints'));
-    return names;
-  }
-
-  get blueprints() {
-    return this.blueprintNames.map((name) => {
-      let blueprintPath = path.join(this.path, 'blueprints', name);
-      let Print = require(blueprintPath).default;
-      return new Print({ name, addon: this, description: Print.description });
-    });
-  }
-
-  hasBlueprint(name) {
-    const names = this.blueprintNames;
-    const blueprint = names.includes(name);
-
-    return !!blueprint;
-  }
-
-  getBlueprint(name) {
-    try {
-      let blueprintPath = path.join(this.path, 'blueprints', name);
-      let Print = require(blueprintPath).default;
-      return new Print({ name, addon: this });
-    } catch (e) {
-      // noop
-    }
-  }
-}

--- a/lib/cli/commands/index.js
+++ b/lib/cli/commands/index.js
@@ -1,10 +1,10 @@
 import 'babel-polyfill';
 import path from 'path';
-import resolve from 'resolve';
 import findup from 'findup-sync';
 import ui from '../lib/ui';
-import tryRequire from '../../utils/try-require';
 import topsort from '../../utils/topsort';
+import tryRequire from '../../utils/try-require';
+import discoverAddons from '../../utils/discover-addons';
 import assign from 'lodash/assign';
 import findKey from 'lodash/findKey';
 import forIn from 'lodash/forIn';
@@ -32,9 +32,26 @@ if (projectPkgPath) {
 let commands = {};
 
 if (isDenaliPkg) {
-  // Load the available addon commands by recusring through the dependency graph
-  // and loading the 'commands.js' file for each addon
   let addons = discoverAddons(process.cwd());
+
+  // Load the available addon commands by recursing through the dependency graph
+  // and loading the 'commands.js' file for each addon
+  addons = addons.map((details) => {
+    let addonPkg = details.pkg;
+    let addonDir = details.dir;
+    let addonCommands = tryRequire(path.join(addonDir, 'commands'));
+    // Tack on the source addon of each addon-supplied command
+    forIn(addonCommands, (addonCommand) => {
+      addonCommand._addon = addonPkg;
+    });
+
+    return {
+      name: details.name,
+      before: details.before,
+      after: details.after,
+      value: addonCommands
+    };
+  });
   addons = topsort(addons, { valueKey: 'value' });
 
   // Merge the depedency graph so that later addons take precedence over earlier
@@ -89,32 +106,3 @@ let command = new commands[fullCommandName]();
 // Invoke the command
 command._run(argTokens, commands);
 
-function discoverAddons(pkgDir, addons = []) {
-  let pkg = require(path.join(pkgDir, 'package.json'));
-  forIn(pkg.dependencies, (version, pkgName) => {
-    let depMainPath = resolve.sync(pkgName, { basedir: pkgDir });
-    let depPkgPath = findup(depMainPath, 'package.json');
-    let depDir = path.dirname(depPkgPath);
-
-    let depPkg = require(depPkgPath);
-    let isDenaliAddon = depPkg.keywords && depPkg.keywords.includes('denali-addon');
-
-    if (isDenaliAddon) {
-      let loadOptions = depPkg.denali || {};
-
-      let addonCommands = tryRequire(path.join(depDir, 'commands'));
-      // Tack on the source addon of each addon-supplied command
-      forIn(addonCommands, (addonCommand) => {
-        addonCommand._addon = depPkg;
-      });
-      addons.push({
-        name: depPkg.name,
-        value: addonCommands,
-        before: loadOptions.before,
-        after: loadOptions.after
-      });
-      discoverAddons(depDir, addons);
-    }
-  });
-  return addons;
-}

--- a/lib/cli/commands/index.js
+++ b/lib/cli/commands/index.js
@@ -2,9 +2,8 @@ import 'babel-polyfill';
 import path from 'path';
 import findup from 'findup-sync';
 import ui from '../lib/ui';
-import topsort from '../../utils/topsort';
 import tryRequire from '../../utils/try-require';
-import discoverAddons from '../../utils/discover-addons';
+import Project from '../lib/project';
 import assign from 'lodash/assign';
 import findKey from 'lodash/findKey';
 import forIn from 'lodash/forIn';
@@ -29,10 +28,13 @@ if (projectPkgPath) {
   isDenaliPkg = projectPkg.keywords && (projectPkg.keywords.includes('denali-addon') || projectPkg.dependencies.denali);
 }
 
+// Process the command line arguments
+let argTokens = process.argv.slice(2);
+let project = new Project();
 let commands = {};
 
 if (isDenaliPkg) {
-  let addons = discoverAddons(process.cwd());
+  let addons = project.addons;
 
   // Load the available addon commands by recursing through the dependency graph
   // and loading the 'commands.js' file for each addon
@@ -52,7 +54,6 @@ if (isDenaliPkg) {
       value: addonCommands
     };
   });
-  addons = topsort(addons, { valueKey: 'value' });
 
   // Merge the depedency graph so that later addons take precedence over earlier
   // ones in case of conflicting command names
@@ -76,11 +77,8 @@ let coreCommands = {
   test: TestCommand
 };
 
-// Core commands take absolute precdence over all others
+// Core commands take absolute precedence over all others
 commands = assign(commands, coreCommands);
-
-// Process the command line arguments
-let argTokens = process.argv.slice(2);
 
 // If no subcommand was supplied, then treat that as the 'root' subcommand
 let suppliedCommand;
@@ -104,5 +102,5 @@ if (!fullCommandName) {
 let command = new commands[fullCommandName]();
 
 // Invoke the command
-command._run(argTokens, commands);
+command._run(argTokens, project, commands);
 

--- a/lib/cli/commands/new.js
+++ b/lib/cli/commands/new.js
@@ -19,7 +19,9 @@ Takes care of setting up a git repo and installing npm dependencies as well.
   allowExtraArgs = true;
 
   run(args, argTokens) {
-    let blueprint = new AppBlueprint();
+    let blueprint = new AppBlueprint({
+      name: 'app'
+    });
     blueprint.generate(this.parseArgs.call(blueprint, argTokens));
   }
 

--- a/lib/cli/lib/blueprint.js
+++ b/lib/cli/lib/blueprint.js
@@ -48,7 +48,9 @@ export default class Blueprint {
   flags = {};
 
   constructor(options) {
-    this.dir = options.dir;
+    this.name = options.name;
+    this.addon = options.addon;
+    this.description = options.description;
   }
 
   /**
@@ -80,6 +82,21 @@ export default class Blueprint {
   postUninstall() {}
 
   /**
+   * Returns the directory path of this blueprint
+   *
+   * @private
+   * @property
+   * @type {String}
+   */
+  get path() {
+    return path.join(this.addon.path, 'blueprints', this.name);
+  }
+
+  get namespace() {
+    return this.addon.name;
+  }
+
+  /**
    * Returns the path to this blueprints template files directory. Defaults to
    * `files/`.
    *
@@ -87,7 +104,7 @@ export default class Blueprint {
    * @return {String}
    */
   get templateFiles() {
-    return path.join(this.dir, 'files');
+    return path.join(this.path, 'files');
   }
 
   /**

--- a/lib/cli/lib/blueprint.js
+++ b/lib/cli/lib/blueprint.js
@@ -47,7 +47,7 @@ export default class Blueprint {
 
   flags = {};
 
-  constructor(options) {
+  constructor(options = {}) {
     this.name = options.name;
     this.addon = options.addon;
     this.description = options.description;
@@ -89,11 +89,12 @@ export default class Blueprint {
    * @type {String}
    */
   get path() {
-    return path.join(this.addon.dir, 'blueprints', this.name);
+    let baseDir = this.addon ? this.addon.dir : '../../';
+    return path.join(baseDir, 'blueprints', this.name);
   }
 
   get namespace() {
-    return this.addon.name;
+    return this.addon ? this.addon.name : 'denali';
   }
 
   /**

--- a/lib/cli/lib/blueprint.js
+++ b/lib/cli/lib/blueprint.js
@@ -119,27 +119,30 @@ export default class Blueprint {
   generate({ params, flags }) {
     let data = this.locals(params, flags);
     let dest = process.cwd();
+    let exists = fs.existsSync(this.templateFiles);
 
-    walk(this.templateFiles).forEach((relativepath) => {
-      let absolutepath = path.resolve(path.join(this.templateFiles, relativepath));
-      if (isDir(absolutepath)) {
-        return null;
-      }
+    if (exists) {
+      walk(this.templateFiles).forEach((relativepath) => {
+        let absolutepath = path.resolve(path.join(this.templateFiles, relativepath));
+        if (isDir(absolutepath)) {
+          return null;
+        }
 
-      let filenameTemplate = template(relativepath, { interpolate: /__([\S]+)__/g });
-      let destRelativepath = filenameTemplate(data);
-      let destAbsolutepath = path.join(dest, destRelativepath);
+        let filenameTemplate = template(relativepath, { interpolate: /__([\S]+)__/g });
+        let destRelativepath = filenameTemplate(data);
+        let destAbsolutepath = path.join(dest, destRelativepath);
 
-      if (fs.existsSync(destAbsolutepath)) {
-        return ui.info(`   ${ chalk.green('already exists') } ${ destRelativepath }`);
-      }
+        if (fs.existsSync(destAbsolutepath)) {
+          return ui.info(`   ${ chalk.green('already exists') } ${ destRelativepath }`);
+        }
 
-      let contents = fs.readFileSync(absolutepath, 'utf-8');
-      let contentsTemplate = template(contents);
-      mkdirp.sync(path.dirname(destAbsolutepath));
-      fs.writeFileSync(destAbsolutepath, contentsTemplate(data));
-      ui.info(`  ${ chalk.green('create') } ${ destRelativepath }`);
-    });
+        let contents = fs.readFileSync(absolutepath, 'utf-8');
+        let contentsTemplate = template(contents);
+        mkdirp.sync(path.dirname(destAbsolutepath));
+        fs.writeFileSync(destAbsolutepath, contentsTemplate(data));
+        ui.info(`  ${ chalk.green('create') } ${ destRelativepath }`);
+      });
+    }
 
     this.postInstall(params, flags);
   }

--- a/lib/cli/lib/blueprint.js
+++ b/lib/cli/lib/blueprint.js
@@ -89,7 +89,7 @@ export default class Blueprint {
    * @type {String}
    */
   get path() {
-    return path.join(this.addon.path, 'blueprints', this.name);
+    return path.join(this.addon.dir, 'blueprints', this.name);
   }
 
   get namespace() {

--- a/lib/cli/lib/blueprint.js
+++ b/lib/cli/lib/blueprint.js
@@ -8,8 +8,6 @@ import ui from './ui';
 import isDir from '../../utils/is-dir';
 import template from 'lodash/template';
 
-const blueprintsDir = path.join(__dirname, '..', 'blueprints');
-
 /**
  * The Blueprint class manages generating code from a template, or "blueprint".
  * Blueprints have three main components:
@@ -49,6 +47,10 @@ export default class Blueprint {
 
   flags = {};
 
+  constructor(options) {
+    this.dir = options.dir;
+  }
+
   /**
    * A hook to generate data to be interpolated into the blueprint's template
    * files.
@@ -85,7 +87,7 @@ export default class Blueprint {
    * @return {String}
    */
   get templateFiles() {
-    return path.join(blueprintsDir, this.constructor.blueprintName, 'files');
+    return path.join(this.dir, 'files');
   }
 
   /**

--- a/lib/cli/lib/command.js
+++ b/lib/cli/lib/command.js
@@ -117,7 +117,9 @@ export default class Command {
     if (this.runsInApp) {
       process.chdir(projectDir);
     }
-    this.run(this.parseArgs(argTokens), project, argTokens, commands);
+    let args = this.parseArgs(argTokens);
+    project.environment = args.environment;
+    this.run(args, argTokens, project, commands);
   }
 
   isDenaliApp() {

--- a/lib/cli/lib/command.js
+++ b/lib/cli/lib/command.js
@@ -103,7 +103,7 @@ export default class Command {
     throw new Error('You must implement a `run()` method');
   }
 
-  _run(argTokens, commands) {
+  _run(argTokens, project, commands) {
     if (includes(argTokens, '-h') || includes(argTokens, '--help')) {
       return this.printHelp(commands);
     }
@@ -117,7 +117,7 @@ export default class Command {
     if (this.runsInApp) {
       process.chdir(projectDir);
     }
-    this.run(this.parseArgs(argTokens), argTokens, commands);
+    this.run(this.parseArgs(argTokens), project, argTokens, commands);
   }
 
   isDenaliApp() {

--- a/lib/cli/lib/project.js
+++ b/lib/cli/lib/project.js
@@ -25,7 +25,9 @@ export default class Project {
     this.lint = options.lint;
     this.audit = options.audit;
 
-    this.addons = discoverAddons(this.dir, { environment: this.environment });
+    this.addons = discoverAddons(this.dir, {
+      environment: this.environment
+    });
     this.buildTree = this._createBuildTree();
     this.builder = new broccoli.Builder(this.buildTree);
   }
@@ -105,7 +107,7 @@ export default class Project {
   }
 
   _createBuildTree() {
-    let dirs = [ 'app', 'config' ];
+    let dirs = [ 'app', 'config', 'blueprints' ];
     if (this.environment === 'test') {
       dirs.push('test');
     }
@@ -117,23 +119,20 @@ export default class Project {
     // We do this first because broccoli-lint-eslint is weird
     // https://github.com/ember-cli/broccoli-lint-eslint/pull/25
     if (this.lint) {
-      // If it's in test environment, generate test modules for each linted file
-      if (this.environment === 'test') {
-        let lintTestTrees = sourceTrees.map((dir) => {
-          return new LintTree(dir, {
-            testGenerator: mochaLintGenerator,
-            format() {
-              return '\r';
-            }
-          });
+      let lintTestTrees = sourceTrees.map((dir) => {
+        return new LintTree(dir, {
+          testGenerator: mochaLintGenerator,
+          format() {
+            return '\r';
+          }
         });
-        let lintTestTree = new MergeTree(lintTestTrees);
-        lintTestTree = new Funnel(lintTestTree, { destDir: 'test/lint' });
-        sourceTrees.push(lintTestTree);
-      // Otherwise, just lint and move on
-      } else {
-        sourceTrees = sourceTrees.map((dir) => new LintTree(dir));
-      }
+      });
+      let lintTestTree = new MergeTree(lintTestTrees);
+      lintTestTree = new Funnel(lintTestTree, { destDir: 'test/lint' });
+      sourceTrees.push(lintTestTree);
+    // Otherwise, just lint and move on
+    } else {
+      sourceTrees = sourceTrees.map((dir) => new LintTree(dir));
     }
 
     let tree = new MergeTree(sourceTrees);
@@ -218,6 +217,8 @@ function mochaLintGenerator(relativePath, errors, results) {
   } else {
     output += dedent`// ESLint failed
                      let error = new AssertionError('${ escape(messages) }');
+                     error.stack = undefined;
+                     throw error;
                      error.stack = undefined;
                      throw error;
 `.trim();

--- a/lib/cli/lib/project.js
+++ b/lib/cli/lib/project.js
@@ -128,7 +128,9 @@ export default class Project {
         });
       });
       let lintTestTree = new MergeTree(lintTestTrees);
-      lintTestTree = new Funnel(lintTestTree, { destDir: 'test/lint' });
+      lintTestTree = new Funnel(lintTestTree, {
+        destDir: 'test/lint'
+      });
       sourceTrees.push(lintTestTree);
     // Otherwise, just lint and move on
     } else {
@@ -152,7 +154,7 @@ export default class Project {
     // Now the standard Denali build
     let transpiled = new Funnel(tree, {
       include: dirs.map((dir) => `${ dir }/**/*.js`),
-      exlcude: ['blueprints/*/files/**']
+      exclude: ['blueprints/*/files/**/*.js']
     });
     transpiled = new BabelTree(transpiled, {
       presets: [ 'latest' ],

--- a/lib/cli/lib/project.js
+++ b/lib/cli/lib/project.js
@@ -151,7 +151,8 @@ export default class Project {
 
     // Now the standard Denali build
     let transpiled = new Funnel(tree, {
-      include: dirs.map((dir) => `${ dir }/**/*.js`)
+      include: dirs.map((dir) => `${ dir }/**/*.js`),
+      exlcude: ['blueprints/*/files/**']
     });
     transpiled = new BabelTree(transpiled, {
       presets: [ 'latest' ],

--- a/lib/cli/lib/project.js
+++ b/lib/cli/lib/project.js
@@ -19,15 +19,13 @@ import tryRequire from '../../utils/try-require';
 
 export default class Project {
 
-  constructor(options) {
+  constructor(options = {}) {
     this.environment = options.environment || 'development';
     this.dir = options.dir || process.cwd();
     this.lint = options.lint;
     this.audit = options.audit;
 
-    this.addons = discoverAddons(this.dir, {
-      environment: this.environment
-    });
+    this.addons = discoverAddons(this.dir);
     this.buildTree = this._createBuildTree();
     this.builder = new broccoli.Builder(this.buildTree);
   }
@@ -154,7 +152,7 @@ export default class Project {
     // Now the standard Denali build
     let transpiled = new Funnel(tree, {
       include: dirs.map((dir) => `${ dir }/**/*.js`),
-      exclude: ['blueprints/*/files/**/*.js']
+      exclude: [ 'blueprints/*/files/**/*.js' ]
     });
     transpiled = new BabelTree(transpiled, {
       presets: [ 'latest' ],

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,3 +56,6 @@ export { default as Service } from './runtime/service';
 // Test
 export { default as setupApp } from './test/setup-app';
 export { version } from '../../package.json';
+
+// CLI
+export { default as Blueprint } from './cli/lib/blueprint';

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -338,4 +338,34 @@ export default class Addon {
     return configModule && (configModule.default || configModule);
   }
 
+  get blueprintNames() {
+    let names = fs.readdirSync(path.join(this.dir, 'blueprints'));
+    return names;
+  }
+
+  get blueprints() {
+    return this.blueprintNames.map((name) => {
+      let blueprintPath = path.join(this.dir, 'blueprints', name);
+      let Print = require(blueprintPath).default;
+      return new Print({ name, addon: this, description: Print.description });
+    });
+  }
+
+  hasBlueprint(name) {
+    const names = this.blueprintNames;
+    const blueprint = names.includes(name);
+
+    return Boolean(blueprint);
+  }
+
+  getBlueprint(name) {
+    try {
+      let blueprintPath = path.join(this.dir, 'blueprints', name);
+      let Blueprint = require(blueprintPath).default;
+      return new Blueprint({ name, addon: this });
+    } catch (e) {
+      // noop
+    }
+  }
+
 }

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -354,6 +354,19 @@ export default class Addon {
 
   get blueprints() {
     return this.blueprintNames.map((name) => {
+      return this.getBlueprint(name);
+    });
+  }
+
+  hasBlueprint(name) {
+    const names = this.blueprintNames;
+    const blueprint = names.includes(name);
+
+    return Boolean(blueprint);
+  }
+
+  getBlueprint(name) {
+    try {
       let blueprint = this._blueprintCache[name];
 
       if (!blueprint) {
@@ -368,23 +381,8 @@ export default class Addon {
       }
 
       return blueprint;
-    });
-  }
-
-  hasBlueprint(name) {
-    const names = this.blueprintNames;
-    const blueprint = names.includes(name);
-
-    return Boolean(blueprint);
-  }
-
-  getBlueprint(name) {
-    try {
-      let blueprintPath = path.join(this.dir, 'blueprints', name);
-      let Blueprint = require(blueprintPath).default;
-      return new Blueprint({ name, addon: this });
     } catch (e) {
-      // noop
+      return false;
     }
   }
 

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -194,7 +194,6 @@ export default class Addon {
       pkg = require(path.join(directory, 'package.json'));
       AddonClass = require(path.join(directory, 'app', 'addon.js'));
     } catch (e) {
-      console.log(e);
       this.logger.error(`Error loading an addon from ${ directory }:`);
       this.logger.error(e);
       throw e;

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -96,6 +96,14 @@ export default class Addon {
   _config;
 
   /**
+   * The cache that stores blueprint instances by name.
+   *
+   * @property _blueprintCache
+   * @type {Object}
+   */
+  _blueprintCache;
+
+  /**
    * Which file extensions should be autoloaded into the container.
    *
    * @property autoLoadExtensions
@@ -110,6 +118,7 @@ export default class Addon {
     this.container = options.container;
     this.logger = options.logger;
 
+    this._blueprintCache = {};
     this.pkg = options.pkg || tryRequire(findup('package.json', { cwd: this.dir }));
     this.addons = this.discoverAddons(options.addons || []);
     this._config = this.loadConfig();
@@ -345,13 +354,20 @@ export default class Addon {
 
   get blueprints() {
     return this.blueprintNames.map((name) => {
-      let blueprintPath = path.join(this.dir, 'blueprints', name);
-      let Blueprint = require(blueprintPath).default;
-      return new Blueprint({
-        name,
-        addon: this,
-        description: Blueprint.description
-      });
+      let blueprint = this._blueprintCache[name];
+
+      if (!blueprint) {
+        let blueprintPath = path.join(this.dir, 'blueprints', name);
+        let Blueprint = require(blueprintPath).default;
+        blueprint = new Blueprint({
+          name,
+          addon: this,
+          description: Blueprint.description
+        });
+        this._blueprintCache[name] = blueprint;
+      }
+
+      return blueprint;
     });
   }
 

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -194,6 +194,7 @@ export default class Addon {
       pkg = require(path.join(directory, 'package.json'));
       AddonClass = require(path.join(directory, 'app', 'addon.js'));
     } catch (e) {
+      console.log(e);
       this.logger.error(`Error loading an addon from ${ directory }:`);
       this.logger.error(e);
       throw e;

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -346,8 +346,12 @@ export default class Addon {
   get blueprints() {
     return this.blueprintNames.map((name) => {
       let blueprintPath = path.join(this.dir, 'blueprints', name);
-      let Print = require(blueprintPath).default;
-      return new Print({ name, addon: this, description: Print.description });
+      let Blueprint = require(blueprintPath).default;
+      return new Blueprint({
+        name,
+        addon: this,
+        description: Blueprint.description
+      });
     });
   }
 

--- a/lib/runtime/application.js
+++ b/lib/runtime/application.js
@@ -68,7 +68,6 @@ export default class Application extends Addon {
    */
   instantiateAddons() {
     this.addons.map((details) => {
-      let pkg = require(path.join(details.dir, 'package.json'));
       let AddonClass = require(path.join(details.dir, 'app', 'addon.js'));
       AddonClass = AddonClass.default || AddonClass || Addon;
 

--- a/lib/runtime/application.js
+++ b/lib/runtime/application.js
@@ -39,6 +39,7 @@ export default class Application extends Addon {
     this.router = this.container.lookup('router:main');
     this.logger = this.container.lookup('logger:main');
     this.includeBaseAddon();
+    this.instantiateAddons();
     // Generate config first, since the loading process may need it
     this.config = this.generateConfig();
     // Kick off the recursive load of this application & all child addons
@@ -56,13 +57,30 @@ export default class Application extends Addon {
    * @private
    */
   includeBaseAddon() {
-    const baseAddon = new Addon({
-      dir: path.join(__dirname, 'base'),
-      environment: this.environment,
-      parent: this,
-      container: this.container
-    });
+    let baseAddon = {
+      name: 'base',
+      dir: path.join(__dirname, 'base')
+    };
     this.addons.unshift(baseAddon);
+  }
+
+  /**
+   */
+  instantiateAddons() {
+    this.addons.map((details) => {
+      let pkg = require(path.join(details.dir, 'package.json'));
+      let AddonClass = require(path.join(details.dir, 'app', 'addon.js'));
+      AddonClass = AddonClass.default || AddonClass || Addon;
+
+      return new AddonClass({
+        name: details.name,
+        dir: details.dir,
+        description: AddonClass.description,
+        environment: this.environment,
+        container: this.container,
+        parent: this
+      });
+    });
   }
 
   /**

--- a/lib/utils/discover-addons.js
+++ b/lib/utils/discover-addons.js
@@ -3,7 +3,6 @@ import resolve from 'resolve';
 import findup from 'find-up';
 import forIn from 'lodash/forIn';
 import topsort from './topsort';
-import Addon from '../runtime/addon';
 
 export default function discoverAddons(dir, options = {}) {
   let addons = [];
@@ -27,42 +26,15 @@ export default function discoverAddons(dir, options = {}) {
     let isDenaliAddon = addonPkg.keywords && addonPkg.keywords.includes('denali-addon');
 
     if (isDenaliAddon) {
-      addons.push(createAddonFromDirectory(pkgDir, options));
+      let loadOptions = addonPkg.denali || {};
+      addons.push({
+        name: addonPkg.name,
+        dir: pkgDir,
+        before: loadOptions.before,
+        after: loadOptions.after
+      });
     }
   });
 
-  // Transform into topsort-able format
-  addons = addons.map((addon) => {
-    let loadOptions = addon.pkg.denali || {};
-    return {
-      name: addon.pkg.name,
-      value: addon,
-      before: loadOptions.before,
-      after: loadOptions.after
-    };
-  });
-
-  return topsort(addons, { valueKey: 'value' });
-}
-
-/**
- * Given a directory that contains an addon, load that addon and instantiate
- * it's Addon class.
- *
- * @method createAddonFromDirectory
- * @param directory {String} path to the directory containing the addon
- * @return {Addon} the instantiated Addon class representing that directory
- * @private
- */
-function createAddonFromDirectory(directory, parent) {
-  let pkg = require(path.join(directory, 'package.json'));
-  let AddonClass = require(path.join(directory, 'app', 'addon.js'));
-  AddonClass = AddonClass.default || AddonClass || Addon;
-  return new AddonClass({
-    dir: directory,
-    environment: parent.environment,
-    container: parent.container,
-    parent,
-    pkg
-  });
+  return topsort(addons);
 }


### PR DESCRIPTION
See #93 for context.

MVPR

- [x] Find blueprints in addons too
- [x] Handle addon namespaces
- [x] Make sure blueprint addons have their dir correct (currently it's hardcoded https://github.com/denali-js/denali/blob/master/lib/cli/lib/blueprint.js#L15)
- [x] Print addon blueprints in help
- [x] Convert to use new broccoli build changes

Nice To Have

- [ ] Set default blueprint if clobbered, see #93. _I'm not sure if we want this_.