### PR TITLE
[WIP] Fixing addon loading to use new public api for dag-map

### DIFF
--- a/lib/utils/topsort.js
+++ b/lib/utils/topsort.js
@@ -4,7 +4,7 @@ export default function topsort(items, options = {}) {
   let graph = new DAG();
   items.forEach((item) => {
     let value = options.valueKey ? item[options.valueKey] : item;
-    graph.addEdges(item.name, value, item.before, item.after);
+    graph.add(item.name, value, item.before, item.after);
   });
   let sorted = [];
   graph.topsort(({ value }) => {


### PR DESCRIPTION
With the update to `dag-map@2.0.0`, `addEdge` was removed and simplified down to `add`.  Makes it hard to load up add ons 😀 

More details here: https://github.com/krisselden/dag-map/pull/10