### PR TITLE
[cli] Fix typo in resource blueprint description

### DIFF
--- a/lib/cli/blueprints/resource/index.js
+++ b/lib/cli/blueprints/resource/index.js
@@ -7,7 +7,7 @@ import { singularize, pluralize } from 'inflection';
 export default class ResourceBlueprint extends Blueprint {
 
   static blueprintName = 'resource';
-  static description = 'Generates a model, serializer, CRUD actions, and tests for a resoure';
+  static description = 'Generates a model, serializer, CRUD actions, and tests for a resource';
 
   params = [ 'name' ];
 


### PR DESCRIPTION
A typo in the description which showed up when using `denali g`.