### PR TITLE
feat(cli): New `routes` commant printing all routes

### DIFF
--- a/lib/cli/commands/index.js
+++ b/lib/cli/commands/index.js
@@ -11,6 +11,7 @@ import forIn from 'lodash/forIn';
 import AddonCommand from './addon';
 import BuildCommand from './build';
 import ConsoleCommand from './console';
+import RoutesCommand from './routes';
 import RootCommand from './root';
 import DestroyCommand from './destroy';
 import GenerateCommand from './generate';
@@ -47,6 +48,7 @@ let coreCommands = {
   addon: AddonCommand,
   build: BuildCommand,
   console: ConsoleCommand,
+  routes: RoutesCommand,
   root: RootCommand,
   destroy: DestroyCommand,
   generate: GenerateCommand,

--- a/lib/cli/commands/routes.js
+++ b/lib/cli/commands/routes.js
@@ -1,0 +1,65 @@
+import path from 'path';
+import CliTable from 'cli-table2';
+import ui from '../lib/ui';
+import Command from '../lib/command';
+import BuildCommand from './build';
+import tryRequire from '../../utils/try-require';
+
+export default class ConsoleCommand extends Command {
+
+  static commandName = 'routes';
+  static description = 'Display all defined routes within your application.';
+  static longDescription = `
+Displays routes from your application and any routes added by addons.
+Display shows the method, endpoint, and the action associated to that
+route.
+  `;
+
+  params = [];
+
+  flags = {};
+
+  runsInApp = true;
+
+  run() {
+    return BuildCommand.prototype.build.call(this).then(() => {
+      let suppliedEnv = process.env.DENALI_ENV || process.env.NODE_ENV;
+
+      process.env.DENALI_ENV = suppliedEnv || 'development';
+
+      // TODO this command shouldn't need to be aware of /dist
+      const UserApplication = tryRequire(path.join(process.cwd(), 'dist/app/application.js'));
+      if (!UserApplication) {
+        ui.error(`Unable to load your application - expected /app/application.js to export a subclass of Application, but found ${ UserApplication } instead.`);
+        throw new Error('Invalid application export');
+      }
+
+      let application = new UserApplication({
+        environment: process.env.DENALI_ENV || process.env.NODE_ENV || 'development',
+        dir: path.join(process.cwd(), 'dist')
+      });
+
+      return application.runInitializers().then(() => {
+        let routes = application.router.routes;
+        let methods = Object.keys(routes);
+        let table = new CliTable({
+          head: [ 'URL', 'ACTION' ]
+        });
+
+        methods.forEach((method) => {
+          let methodRoutes = routes[method];
+
+          methodRoutes.forEach((route) => {
+            // Only return routes with urls ending with a / since they are duplicated
+            if (route.spec.slice(-1) === '/') {
+              table.push([ `${ method.toUpperCase() } ${ route.spec }`, route.actionPath ]);
+            }
+          });
+        });
+
+        ui.info(table.toString());
+      });
+    });
+  }
+
+}

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -157,8 +157,7 @@ export default class Addon {
     forIn(this.pkg.dependencies, (version, pkgName) => {
       let pkgMainPath = resolve.sync(pkgName, { basedir: this.dir });
       let pkgJSONPath = path.resolve(findup('package.json', { cwd: pkgMainPath }));
-      // TODO this shouldn't need to be aware of dist
-      let pkgDir = path.join(path.dirname(pkgJSONPath), 'dist');
+      let pkgDir = path.dirname(pkgJSONPath);
       let pkg = require(pkgJSONPath);
       let isDenaliAddon = pkg.keywords && pkg.keywords.includes('denali-addon');
 

--- a/lib/utils/topsort.js
+++ b/lib/utils/topsort.js
@@ -7,7 +7,7 @@ export default function topsort(items, options = {}) {
     graph.add(item.name, value, item.before, item.after);
   });
   let sorted = [];
-  graph.topsort(({ value }) => {
+  graph.topsort((key, value) => {
     sorted.push(value);
   });
   return sorted;

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "bluebird": "^3.3.5",
     "body-parser": "^1.14.2",
     "chalk": "^1.1.1",
+    "cli-table2": "^0.2.0",
     "compression": "^1.6.0",
     "cookie-parser": "^1.4.3",
     "cors": "^2.7.1",


### PR DESCRIPTION
`denali routes` will traverse all addons and your app and print the
endpoint, method and the action.

Fixes #103 

cc @acorncom 

![screen shot 2016-09-28 at 6 47 58 pm](https://cloud.githubusercontent.com/assets/34726/18935146/26c213b2-85ac-11e6-817b-384f1a1aaa5c.png)
