### PR TITLE
fix(blueprints): config/routes.js comment for app and addon:

### DIFF
--- a/lib/cli/blueprints/addon/files/__name__/config/routes.js
+++ b/lib/cli/blueprints/addon/files/__name__/config/routes.js
@@ -1,4 +1,4 @@
-export default function drawRoutes() {
+export default function drawRoutes(/* router */) {
 
   /*
    * # Single routes
@@ -6,15 +6,19 @@ export default function drawRoutes() {
    * If you have some custom endpoint you want to create, you can always add it
    * via the basic routing DSL:
    *
-   *     this.post('/foo', 'foo', 'process')
-   *          └┬─┘ └┬───┘  └┬──┘  └┬──────┘
-   *           │    │       │      └ action name
-   *           │    │       └ controller
+   *   router.post('/foo', 'foo')
+   *          └┬─┘ └┬───┘  └┬──┘
+   *           │    │       │
+   *           │    │       └ action
    *           │    └ URL pattern
    *           └ HTTP method
    *
    * That will create an endpoint that responds to a POST /foo, and triggers the
-   * `process` action on the `foo` controller.
+   * `foo` action.
+   *
+   * Nested actions can be references via their path:
+   *
+   *   router.post('/comments/:id/replies', 'comments/replies/create')
    *
    *
    * # Resources
@@ -22,9 +26,9 @@ export default function drawRoutes() {
    * Single routes are useful, but Denali's real power comes from resources.
    * Using just:
    *
-   *     this.resource('book')
+   *   router.resource('book')
    *
-   * sets up the following routes
+   * sets up the following routes mapped to actions in the `books/` folder:
    *
    * Method  | URL                                               | Action
    * --------|---------------------------------------------------|-------

--- a/lib/cli/blueprints/app/files/__name__/config/routes.js
+++ b/lib/cli/blueprints/app/files/__name__/config/routes.js
@@ -8,7 +8,7 @@ export default function drawRoutes(router) {
    * If you have some custom endpoint you want to create, you can always add it
    * via the basic routing DSL:
    *
-   *     this.post('/foo', 'foo')
+   *   router.post('/foo', 'foo')
    *          └┬─┘ └┬───┘  └┬──┘
    *           │    │       │
    *           │    │       └ action
@@ -20,7 +20,7 @@ export default function drawRoutes(router) {
    *
    * Nested actions can be references via their path:
    *
-   *     this.post('/comments/:id/replies', 'comments/replies/create');
+   *   router.post('/comments/:id/replies', 'comments/replies/create')
    *
    *
    * # Resources
@@ -28,7 +28,7 @@ export default function drawRoutes(router) {
    * Single routes are useful, but Denali's real power comes from resources.
    * Using just:
    *
-   *     this.resource('book')
+   *   router.resource('book')
    *
    * sets up the following routes mapped to actions in the `books/` folder:
    *


### PR DESCRIPTION
Both were still referencing `this` as the way to add a route. Was more of an issue for an addon since there wasn't already a default route created.