### PR TITLE
fix(data): pluralize types in json-api serializer

### DIFF
--- a/lib/data/serializers/json-api.js
+++ b/lib/data/serializers/json-api.js
@@ -4,7 +4,7 @@
  */
 import assert from 'assert';
 import path from 'path';
-import { pluralize } from 'inflection';
+import { singularize, pluralize } from 'inflection';
 import Serializer from '../serializer';
 import Model from '../model';
 import Errors from '../../runtime/errors';
@@ -172,7 +172,7 @@ export default class JSONAPISerializer extends Serializer {
   static renderRecord(record, document, options = {}) {
     assert(record, `Cannot serialize ${ record }. You supplied ${ record } instead of a Model instance.`);
     let serializedRecord = {
-      type: record.constructor.type,
+      type: pluralize(record.constructor.type),
       id: record.id
     };
     assert(serializedRecord.id != null, `Attempted to serialize a record (${ record }) without an id, but the JSON-API spec requires all resources to have an id.`);
@@ -337,7 +337,7 @@ export default class JSONAPISerializer extends Serializer {
     if (relatedRecordOrId instanceof Model) {
       this.includeRecord(name, relatedRecordOrId, descriptor, context);
       return {
-        type: relatedRecordOrId.constructor.type,
+        type: pluralize(relatedRecordOrId.constructor.type),
         id: relatedRecordOrId.id
       };
     }
@@ -592,7 +592,7 @@ export default class JSONAPISerializer extends Serializer {
    * @return {String} the parsed type
    */
   static parseType(type) {
-    return type;
+    return singularize(type);
   }
 
   /**


### PR DESCRIPTION
While the spec doesn't require this, pluralizing type strings is the
recommended approach, so will stick with that.