### PR TITLE
feat(data): expose memory orm-adapter cache

### DIFF
--- a/lib/data/orm-adapters/memory.js
+++ b/lib/data/orm-adapters/memory.js
@@ -1,22 +1,23 @@
 import { filter, pluck, remove } from 'lodash';
 import ORMAdapter from '../orm-adapter';
 
-const cache = {};
-const typeKey = Symbol('memory-adapter-type');
 let guid = 0;
 
 export default class MemoryAdapter extends ORMAdapter {
 
+  static _typeKey = Symbol('memory-adapter-type');
+  static _cache = {};
+
   static find(type, query) {
     if (typeof query === 'number' || typeof query === 'string') {
-      return (cache[type] && cache[type][query]) || null;
+      return (this._cache[type] && this._cache[type][query]) || null;
     }
-    return filter(cache[type] || {}, query);
+    return filter(this._cache[type] || {}, query);
   }
 
   static buildRecord(type, data) {
-    cache[type] = cache[type] || {};
-    data[typeKey] = type;
+    this._cache[type] = this._cache[type] || {};
+    data[this._typeKey] = type;
     return data;
   }
 
@@ -38,7 +39,7 @@ export default class MemoryAdapter extends ORMAdapter {
   }
 
   static getRelated(record, relationship, descriptor) {
-    let relatedCollection = cache[descriptor.type];
+    let relatedCollection = this._cache[descriptor.type];
     if (descriptor.mode === 'hasMany') {
       return filter(relatedCollection, (relatedRecord) => {
         return record[`${ relationship }_ids`].contains(relatedRecord.id);
@@ -63,19 +64,19 @@ export default class MemoryAdapter extends ORMAdapter {
     remove(record[`${ relationship }_ids`], { id: relatedRecord.id });
   }
 
-  static saveRecord(record) {
-    let collection = cache[record[typeKey]];
-    if (record.id == null) {
+  static saveRecord(model) {
+    let collection = this._cache[model.record[this._typeKey]];
+    if (model.record.id == null) {
       guid += 1;
-      record.id = guid;
+      model.record.id = guid;
     }
-    collection[record.id] = record;
-    return record;
+    collection[model.record.id] = model.record;
+    return model;
   }
 
-  static deleteRecord(record) {
-    let collection = cache[record[typeKey]];
-    delete collection[record.id];
+  static deleteRecord(model) {
+    let collection = this._cache[model.record[this._typeKey]];
+    delete collection[model.record.id];
   }
 
 }


### PR DESCRIPTION
This is useful primarily for testing, to be able to clear the in-memory
data cache after each test.