### PR TITLE
feat(data): pass model to orm adapter

### DIFF
--- a/lib/data/model.js
+++ b/lib/data/model.js
@@ -134,7 +134,7 @@ export default class Model {
    * @type {Number|String}
    */
   get id() {
-    return this.adapter.idFor(this.record);
+    return this.adapter.idFor(this);
   }
 
   /**
@@ -181,7 +181,7 @@ export default class Model {
           // Return the attribute value if that's what is requested
           let descriptor = model.constructor[property];
           if (descriptor && descriptor.isAttribute) {
-            return model.adapter.getAttribute(model.record, property);
+            return model.adapter.getAttribute(model, property);
           }
           // Forward relationship related methods to their generic counterparts
           let relatedMethodParts = property.match(/(get|set|add|remove)(\w+)/);
@@ -203,7 +203,7 @@ export default class Model {
         // Set attribute values
         let descriptor = model.constructor[property];
         if (descriptor && descriptor.isAttribute) {
-          return model.adapter.setAttribute(model.record, property, value);
+          return model.adapter.setAttribute(model, property, value);
         }
         // Otherwise just set the model property directly
         model[property] = value;
@@ -214,7 +214,7 @@ export default class Model {
         // Delete the attribute
         let descriptor = model.constructor[property];
         if (descriptor && descriptor.isAttribute) {
-          return model.adapter.deleteAttribute(model.record, property);
+          return model.adapter.deleteAttribute(model, property);
         }
         // Otherwise just delete the model property directly
         return delete model[property];
@@ -231,7 +231,7 @@ export default class Model {
    * @return {Promise}
    */
   save(options) {
-    return Promise.try(() => this.adapter.saveRecord(this.record, options))
+    return Promise.try(() => this.adapter.saveRecord(this, options))
       .return(this);
   }
 
@@ -243,7 +243,7 @@ export default class Model {
    * @return {Promise}
    */
   delete(options) {
-    return Promise.try(() => this.adapter.deleteRecord(this.record, options));
+    return Promise.try(() => this.adapter.deleteRecord(this, options));
   }
 
   /**
@@ -258,7 +258,7 @@ export default class Model {
   getRelated(relationshipName, options) {
     let descriptor = this.constructor[relationshipName] || this.constructor[pluralize(relationshipName)];
     assert(descriptor && descriptor.isRelationship, `You tried to fetch related ${ relationshipName }, but no such relationship exists on ${ this.constructor.type }`);
-    return Promise.try(() => this.adapter.getRelated(this.record, relationshipName, descriptor, options))
+    return Promise.try(() => this.adapter.getRelated(this, relationshipName, descriptor, options))
       .then((results) => {
         let RelatedModel = this.modelFor(descriptor.type);
         if (descriptor.mode === 'hasOne') {
@@ -280,8 +280,7 @@ export default class Model {
    */
   setRelated(relationshipName, relatedModels, options) {
     let descriptor = this.constructor[relationshipName] || this.constructor[pluralize(relationshipName)];
-    let relatedRecords = relatedModels.map((model) => model.record);
-    return Promise.try(() => this.adapter.setRelated(this.record, relationshipName, descriptor, relatedRecords, options));
+    return Promise.try(() => this.adapter.setRelated(this, relationshipName, descriptor, relatedModels, options));
     // TODO force a null return?
   }
 
@@ -296,7 +295,7 @@ export default class Model {
    */
   addRelated(relationshipName, relatedModel, options) {
     let descriptor = this.constructor[relationshipName] || this.constructor[pluralize(relationshipName)];
-    return Promise.try(() => this.adapter.addRelated(this.record, relationshipName, descriptor, relatedModel, options))
+    return Promise.try(() => this.adapter.addRelated(this, relationshipName, descriptor, relatedModel, options))
       .then((results) => {
         let RelatedModel = this.modelFor(descriptor.type);
         return results.map((record) => new RelatedModel(record));
@@ -314,7 +313,7 @@ export default class Model {
    */
   removeRelated(relationshipName, relatedModel, options) {
     let descriptor = this.constructor[relationshipName] || this.constructor[pluralize(relationshipName)];
-    return Promise.try(() => this.adapter.removeRelated(this.record, relationshipName, descriptor, relatedModel, options))
+    return Promise.try(() => this.adapter.removeRelated(this, relationshipName, descriptor, relatedModel, options))
       .then((results) => {
         let RelatedModel = this.modelFor(descriptor.type);
         return results.map((record) => new RelatedModel(record));

--- a/lib/data/orm-adapters/memory.js
+++ b/lib/data/orm-adapters/memory.js
@@ -21,47 +21,47 @@ export default class MemoryAdapter extends ORMAdapter {
     return data;
   }
 
-  static idFor(record) {
-    return record.id;
+  static idFor(model) {
+    return model.record.id;
   }
 
-  static getAttribute(record, property) {
-    return record[property];
+  static getAttribute(model, property) {
+    return model.record[property];
   }
 
-  static setAttribute(record, property, value) {
-    record[property] = value;
+  static setAttribute(model, property, value) {
+    model.record[property] = value;
     return true;
   }
 
-  static deleteAttribute(record, property) {
-    record[property] = null;
+  static deleteAttribute(model, property) {
+    model.record[property] = null;
   }
 
-  static getRelated(record, relationship, descriptor) {
+  static getRelated(model, relationship, descriptor) {
     let relatedCollection = this._cache[descriptor.type];
     if (descriptor.mode === 'hasMany') {
       return filter(relatedCollection, (relatedRecord) => {
-        return record[`${ relationship }_ids`].contains(relatedRecord.id);
+        return model.record[`${ relationship }_ids`].contains(relatedRecord.id);
       });
     }
-    return this.find(relatedCollection, { id: record[`${ relationship }_id`] });
+    return this.find(relatedCollection, { id: model.record[`${ relationship }_id`] });
   }
 
-  static setRelated(record, relationship, descriptor, relatedRecords) {
+  static setRelated(model, relationship, descriptor, relatedRecords) {
     if (descriptor.mode === 'hasMany') {
-      record[`${ relationship }_ids`] = pluck(relatedRecords, 'id');
+      model.record[`${ relationship }_ids`] = pluck(relatedRecords, 'id');
     } else {
-      record[`${ relationship }_id`] = relatedRecords.id;
+      model.record[`${ relationship }_id`] = relatedRecords.id;
     }
   }
 
-  static addRelated(record, relationship, descriptor, relatedRecord) {
-    record[`${ relationship }_ids`].push(relatedRecord.id);
+  static addRelated(model, relationship, descriptor, relatedRecord) {
+    model.record[`${ relationship }_ids`].push(relatedRecord.id);
   }
 
-  static removeRelated(record, relationship, descriptor, relatedRecord) {
-    remove(record[`${ relationship }_ids`], { id: relatedRecord.id });
+  static removeRelated(model, relationship, descriptor, relatedRecord) {
+    remove(model.record[`${ relationship }_ids`], { id: relatedRecord.id });
   }
 
   static saveRecord(model) {
@@ -71,7 +71,7 @@ export default class MemoryAdapter extends ORMAdapter {
       model.record.id = guid;
     }
     collection[model.record.id] = model.record;
-    return model;
+    return model.record;
   }
 
   static deleteRecord(model) {


### PR DESCRIPTION
The ORM adapter needs access to the user-defined model to support any additional custom options, i.e. Model.tableName