### PR TITLE
fix(guides): Escape *.js so it's not MD

### DIFF
--- a/guides/overview/app-structure.md
+++ b/guides/overview/app-structure.md
@@ -27,7 +27,7 @@ only.
 
 # `config/`
 
-Holds the declarative and executable configuration for your app. *.js files
+Holds the declarative and executable configuration for your app. \*.js files
 (other than `environment.js` and `initializers/*.js`) in this folder will be
 automatically loaded into the container under their filename (i.e.
 `config/foo.js` will be loaded under `config:foo`).


### PR DESCRIPTION
Fix this issue:

<img width="792" alt="screen shot 2016-10-05 at 11 20 36 am" src="https://cloud.githubusercontent.com/assets/34726/19119455/c972ee2e-8aed-11e6-92c3-e638eff4c9bb.png">
