### PR TITLE
revert: data(abstract): re-add abstract property to Denali model API

### DIFF
--- a/lib/cli/blueprints/app/files/__name__/app/models/application.js
+++ b/lib/cli/blueprints/app/files/__name__/app/models/application.js
@@ -1,4 +1,7 @@
 import { Model } from 'denali';
 
 export default class ApplicationModel extends Model {
+
+  static abstract = true;
+
 }


### PR DESCRIPTION
See https://github.com/denali-js/denali-node-orm2/pull/1#discussion_r82480573
for further discussion

Revert "remove obsolete `abstract` property from application model blueprint"

This reverts commit 59ec7e0adc237ec7b7b26eb00a0a9e98ab3e8573.