### PR TITLE
fix(cli): Fix paths to the built assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 require('source-map-support').install();
-module.exports = require('./dist');
+module.exports = require('./dist/lib');

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,4 +55,4 @@ export { default as Service } from './runtime/service';
 
 // Test
 export { default as setupApp } from './test/setup-app';
-export { version } from '../package.json';
+export { version } from '../../package.json';


### PR DESCRIPTION
- `package.json` is now one more directory away.
- lib index is not at the top level of the `dist` dir.

See #145 for context