### PR TITLE
WIP: feat(router): run middleware layer prior to routing

### DIFF
--- a/lib/runtime/router.js
+++ b/lib/runtime/router.js
@@ -77,22 +77,23 @@ export default class Router {
    * @private
    */
   handle(req, response) {
-    let request = new Request(req);
-    let routes = this.routes[request.method];
-    for (let i = 0; i < routes.length; i += 1) {
-      request.params = routes[i].match(request.path);
-      if (request.params) {
-        request.route = routes[i];
-        break;
-      }
-    }
-    if (!request.route) {
-      return this.handleError(request, response, new Errors.NotFound('Route not recognized'));
-    }
+    this.middleware.run(req, response, (error) => {
 
-    this.middleware.run(request, response, (error) => {
+      let request = new Request(req);
       if (error) {
         return this.handleError(request, response, error);
+      }
+
+      let routes = this.routes[request.method];
+      for (let i = 0; i < routes.length; i += 1) {
+        request.params = routes[i].match(request.path);
+        if (request.params) {
+          request.route = routes[i];
+          break;
+        }
+      }
+      if (!request.route) {
+        return this.handleError(request, response, new Errors.NotFound('Route not recognized'));
       }
 
       // eslint-disable-next-line new-cap


### PR DESCRIPTION
A middleware I'm using basically defines an action at the Node level.  In order for the middleware to work, I need to add an additional action to my `routes.js` file that I never actually intend to use.

Do we want to re-jigger our approach here so middleware run prior to route handling?  I'd be inclined to do that and then have routing fail if no routes were found after that.