### PR TITLE
feat(cli): add yarn support to denali new command

### DIFF
--- a/lib/cli/blueprints/app/index.js
+++ b/lib/cli/blueprints/app/index.js
@@ -19,8 +19,8 @@ export default class AppBlueprint extends Blueprint {
   params = [ 'name' ];
 
   flags = {
-    'skip-npm': {
-      description: 'Do not run npm install on new app',
+    'skip-deps': {
+      description: 'Do not install dependencies on new app',
       defaultValue: false,
       type: Boolean
     }

--- a/lib/cli/blueprints/app/index.js
+++ b/lib/cli/blueprints/app/index.js
@@ -5,8 +5,10 @@ import Promise from 'bluebird';
 import { exec } from 'child_process';
 import startCase from 'lodash/startCase';
 import pkg from '../../../../../package.json';
+import commandExistsCallback from 'command-exists';
 
 const run = Promise.promisify(exec);
+const commandExists = Promise.promisify(commandExistsCallback);
 const maxBuffer = 400 * 1024;
 
 export default class AppBlueprint extends Blueprint {
@@ -36,13 +38,18 @@ export default class AppBlueprint extends Blueprint {
   postInstall({ name }, flags) {
     let spinner = ora();
     ui.info('');
-    spinner.text = 'Installing npm dependencies ...';
+    spinner.text = 'Installing dependencies ...';
     spinner.start();
     return Promise.resolve().then(() => {
-      if (!flags['skip-npm']) {
-        return run('npm install --loglevel=error', { cwd: name }).then(() => {
+      if (!flags['skip-deps']) {
+        return commandExists('yarn').then((yarnExists) => {
+          if (yarnExists) {
+            return run('yarn install', { cwd: name });
+          }
+          return run('npm install --loglevel=error', { cwd: name });
+        }).then(() => {
           spinner.stop();
-          ui.success('Installing npm dependencies ... done ✔');
+          ui.success('Installing dependencies ... done ✔');
         });
       }
     }).then(() => {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "broccoli-merge-trees": "^1.1.4",
     "chalk": "^1.1.1",
     "cli-table2": "^0.2.0",
+    "command-exists": "^1.0.2",
     "compression": "^1.6.0",
     "cookie-parser": "^1.4.3",
     "copy-dereference": "^1.0.0",

--- a/test/acceptance/cli/new-test.js
+++ b/test/acceptance/cli/new-test.js
@@ -17,7 +17,7 @@ describe('new command', function() {
   before(function() {
     this.timeout(20000);
     this.tmpdir = tmp.dirSync({ unsafeCleanup: true });
-    run(`${ denaliPath } new foobar --skip-npm`, { cwd: this.tmpdir.name });
+    run(`${ denaliPath } new foobar --skip-deps`, { cwd: this.tmpdir.name });
   });
 
   after(function() {


### PR DESCRIPTION
If yarn exists, `denali new` will use it to install dependencies rather than npm.