### PR TITLE
fix(blueprint): Remove duplicate eslint dep in app blueprint

### DIFF
--- a/lib/cli/blueprints/app/files/__name__/package.json
+++ b/lib/cli/blueprints/app/files/__name__/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
-    "eslint": "^2.9.0",
     "mocha": "^3.0.2",
     "must": "^0.13.1"
   }


### PR DESCRIPTION
Would error if `yarn` was present during tests.