### PR TITLE
fix(data): fix serializer problems hit when serializer = false

### DIFF
--- a/lib/runtime/router.js
+++ b/lib/runtime/router.js
@@ -90,7 +90,8 @@ export default class Router {
       return this.handleError(request, response, new Errors.NotFound('Route not recognized'));
     }
 
-    this.middleware.run(request, response, (error) => {
+    // this promise is currently unused upstream (though it is in our test code), but may be in the future
+    return Promise.resolve(this.middleware.run(request, response, (error) => {
       if (error) {
         return this.handleError(request, response, error);
       }
@@ -121,11 +122,11 @@ export default class Router {
           request.body = serializer.parse(request.body);
         }
       }).then(() => {
-        return Promise.resolve(action.run());
+        return action.run();
       }).catch((uncaughtError) => {
         this.handleError(request, response, uncaughtError);
       });
-    });
+    }));
   }
 
   /**

--- a/lib/runtime/router.js
+++ b/lib/runtime/router.js
@@ -110,6 +110,8 @@ export default class Router {
         } else {
           serializer = action.serializer;
         }
+      } else if (action.serializer === false) {
+        serializer = null;
       } else {
         serializer = this.container.lookup('serializer:application');
       }
@@ -119,7 +121,7 @@ export default class Router {
           request.body = serializer.parse(request.body);
         }
       }).then(() => {
-        return action.run();
+        return Promise.resolve(action.run());
       }).catch((uncaughtError) => {
         this.handleError(request, response, uncaughtError);
       });

--- a/test/unit/router-test.js
+++ b/test/unit/router-test.js
@@ -1,0 +1,89 @@
+import expect from 'must';
+import Action from '../../lib/runtime/action';
+import Router from '../../lib/runtime/router';
+import Container from '../../lib/runtime/container';
+import FlatSerializer from '../../lib/runtime/base/app/serializers/flat';
+import JSONAPISerializer from '../../lib/runtime/base/app/serializers/json-api';
+import merge from 'lodash/merge';
+
+function mockReqRes(overrides) {
+  let container = new Container();
+
+  container.register('serializer:application', FlatSerializer);
+  container.register('config:environment', {});
+
+  return merge({
+    container,
+    request: {
+      get(headerName) {
+        return this.headers && this.headers[headerName.toLowerCase()];
+      },
+      headers: {
+        'content-type': 'application/json'
+      },
+      query: {},
+      body: {}
+    },
+    response: {
+      write() {},
+      setHeader() {},
+      render() {},
+      end() {}
+    },
+    next() {}
+  }, overrides);
+}
+
+describe.only('Denali.Router', function() {
+
+  it('should not invoke the default serializer if serializer=false in an action', function() {
+    let success = false;
+    let mock = mockReqRes({
+      request: {
+        headers: {
+          'content-type': 'application/json',
+          'transfer-encoding': 'chunked'
+        },
+        method: 'post',
+        url: '/a-path',
+        body: { my: 'post-data' }
+      }
+    });
+    class TestAction extends Action {
+      serializer = false;
+      run() {
+        return new Promise((resolve) => {
+          success = true;
+          resolve();
+        });
+      }
+    }
+
+    // if we do run through this serializer, it will blow up with errors
+    // about the data key which we don't have'
+    mock.container.register('serializer:application', {
+      parse() {
+        throw new Error('Must not use the serializer');
+      }
+    });
+    class TestRouter extends Router {
+      routes = {
+        post: [ {
+          action: TestAction,
+          match() {
+            return true;
+          }
+        } ]
+      }
+      handleError(req, res, uncaughtError) {
+        expect(uncaughtError).to.be.null();
+      }
+    }
+    let router = new TestRouter(mock);
+
+    router.handle(mock.request, mock.response).then(() => {
+      expect(success).to.be.true();
+    });
+  });
+
+});

--- a/test/unit/router-test.js
+++ b/test/unit/router-test.js
@@ -33,7 +33,7 @@ function mockReqRes(overrides) {
   }, overrides);
 }
 
-describe.only('Denali.Router', function() {
+describe('Denali.Router', function() {
 
   it('should not invoke the default serializer if serializer=false in an action', function() {
     let success = false;

--- a/test/unit/router-test.js
+++ b/test/unit/router-test.js
@@ -40,7 +40,6 @@ describe.only('Denali.Router', function() {
     let mock = mockReqRes({
       request: {
         headers: {
-          'content-type': 'application/json',
           'transfer-encoding': 'chunked'
         },
         method: 'post',

--- a/test/unit/router-test.js
+++ b/test/unit/router-test.js
@@ -3,7 +3,6 @@ import Action from '../../lib/runtime/action';
 import Router from '../../lib/runtime/router';
 import Container from '../../lib/runtime/container';
 import FlatSerializer from '../../lib/runtime/base/app/serializers/flat';
-import JSONAPISerializer from '../../lib/runtime/base/app/serializers/json-api';
 import merge from 'lodash/merge';
 
 function mockReqRes(overrides) {


### PR DESCRIPTION
In an `Action`, `serializer = false` is something we're allowed to do (see our default `application` action blueprint) and it should skip our application serializer.

However, we weren't doing that.  This becomes a problem if our default app serializer is a JSON-API serializer (which requires a `data` key) and we POST data into an action (my use case is a webhook).  The serializer gets called unnecessarily.