### PR TITLE
fix(runtime): Instantiate singletons during app load

### DIFF
--- a/lib/cli/lib/project.js
+++ b/lib/cli/lib/project.js
@@ -25,7 +25,9 @@ export default class Project {
     this.lint = options.lint;
     this.audit = options.audit;
 
-    this.addons = discoverAddons(this.dir, { environment: this.environment });
+    this.addons = discoverAddons(this.dir, {
+      environment: this.environment
+    });
     this.buildTree = this._createBuildTree();
     this.builder = new broccoli.Builder(this.buildTree);
   }

--- a/lib/cli/lib/project.js
+++ b/lib/cli/lib/project.js
@@ -144,7 +144,7 @@ export default class Project {
     // own absolute path passed in, in case they want to inject their own assets
     // into the app build
     this.addons.forEach((addon) => {
-      let addonBuild = tryRequire(path.join(addon.dir, 'denali-build.js')) || identity;
+      let addonBuild = tryRequire(path.join(addon.dir, 'app', 'denali-build.js')) || identity;
       tree = addonBuild(tree, this, addon.dir);
     });
 

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -337,8 +337,10 @@ export default class Addon {
         } else if (filepath.endsWith('.json')) {
           let mod = require(path.join(dir, filepath));
           this.container.register(`${ type }:${ modulepath }`, mod.default || mod);
-        } else if (this.autoLoadExtensions.includes(path.extname(filepath))) {
-          this.container.register(`${ type }:${ filepath }`, fs.readFileSync(filepath, 'utf-8'));
+        } else if (this.autoLoadExtensions.includes(path.extname(filepath).slice(1))) {
+          let fullPath = path.join(dir, filepath);
+          let file = fs.readFileSync(fullPath, 'utf-8');
+          this.container.register(`${ type }:${ filepath }`, file);
         }
       });
     });

--- a/lib/runtime/addon.js
+++ b/lib/runtime/addon.js
@@ -323,7 +323,18 @@ export default class Addon {
       let type = singularize(dirname);
       glob.sync('**/*', { cwd: dir }).forEach((filepath) => {
         let modulepath = withoutExt(filepath);
-        if (filepath.endsWith('.js') || filepath.endsWith('.json')) {
+        if (filepath.endsWith('.js')) {
+          let mod = require(path.join(dir, filepath));
+          let Klass = mod.default || mod;
+          let toRegister = Klass;
+
+          if (toRegister.singleton) {
+            toRegister = new Klass();
+            toRegister.container = this.container;
+          }
+
+          this.container.register(`${ type }:${ modulepath }`, toRegister);
+        } else if (filepath.endsWith('.json')) {
           let mod = require(path.join(dir, filepath));
           this.container.register(`${ type }:${ modulepath }`, mod.default || mod);
         } else if (this.autoLoadExtensions.includes(path.extname(filepath))) {

--- a/lib/runtime/application.js
+++ b/lib/runtime/application.js
@@ -59,6 +59,7 @@ export default class Application extends Addon {
     const baseAddon = new Addon({
       dir: path.join(__dirname, 'base'),
       environment: this.environment,
+      logger: this.logger,
       parent: this,
       container: this.container
     });

--- a/lib/runtime/container.js
+++ b/lib/runtime/container.js
@@ -23,15 +23,6 @@ export default class Container {
   _registry = {};
 
   /**
-   * The internal cache of instantiated singletons
-   *
-   * @property _singletonCache
-   * @type {Object}
-   * @private
-   */
-  _singletonCache = {};
-
-  /**
    * A reference to the application config
    *
    * @property config
@@ -139,22 +130,6 @@ export default class Container {
     }
     Serializer.container = this;
     return Serializer;
-  }
-
-  lookupService(parsedName) {
-    let service = this._singletonCache[parsedName];
-
-    if (!service) {
-      let Service = this._lookupOther(parsedName);
-      if (!Service) {
-        throw new Error(`No such service found: ${ parsedName.moduleName }`);
-      }
-      service = new Service();
-      service.container = this;
-      this._singletonCache[parsedName] = service;
-    }
-
-    return service;
   }
 
   /**

--- a/lib/runtime/container.js
+++ b/lib/runtime/container.js
@@ -23,6 +23,15 @@ export default class Container {
   _registry = {};
 
   /**
+   * The internal cache of instantiated singletons
+   *
+   * @property _singletonCache
+   * @type {Object}
+   * @private
+   */
+  _singletonCache = {};
+
+  /**
    * A reference to the application config
    *
    * @property config
@@ -130,6 +139,22 @@ export default class Container {
     }
     Serializer.container = this;
     return Serializer;
+  }
+
+  lookupService(parsedName) {
+    let service = this._singletonCache[parsedName];
+
+    if (!service) {
+      let Service = this._lookupOther(parsedName);
+      if (!Service) {
+        throw new Error(`No such service found: ${ parsedName.moduleName }`);
+      }
+      service = new Service();
+      service.container = this;
+      this._singletonCache[parsedName] = service;
+    }
+
+    return service;
   }
 
   /**

--- a/lib/runtime/service.js
+++ b/lib/runtime/service.js
@@ -13,4 +13,6 @@
  * @module denali
  * @submodule runtime
  */
-export default class Service {}
+export default class Service {
+  static singleton = true;
+}

--- a/lib/utils/discover-addons.js
+++ b/lib/utils/discover-addons.js
@@ -4,6 +4,7 @@ import findup from 'find-up';
 import forIn from 'lodash/forIn';
 import topsort from './topsort';
 import Addon from '../runtime/addon';
+import Logger from '../runtime/logger';
 
 export default function discoverAddons(dir, options = {}) {
   let addons = [];
@@ -62,6 +63,7 @@ function createAddonFromDirectory(directory, parent) {
     dir: directory,
     environment: parent.environment,
     container: parent.container,
+    logger: parent.logger || new Logger(),
     parent,
     pkg
   });

--- a/test/unit/actions-test.js
+++ b/test/unit/actions-test.js
@@ -334,7 +334,7 @@ describe('Denali.Action', function() {
       class MockService extends Service {
       }
 
-      mock.container.register('service:mock', MockService);
+      mock.container.register('service:mock', new MockService());
 
       let action = new TestAction(mock);
 

--- a/test/unit/actions-test.js
+++ b/test/unit/actions-test.js
@@ -3,6 +3,7 @@ import Action from '../../lib/runtime/action';
 import Model from '../../lib/data/model';
 import Response from '../../lib/runtime/response';
 import Container from '../../lib/runtime/container';
+import Service from '../../lib/runtime/service';
 import FlatSerializer from '../../lib/runtime/base/app/serializers/flat';
 import merge from 'lodash/merge';
 
@@ -324,19 +325,21 @@ describe('Denali.Action', function() {
       let service;
       class TestAction extends Action {
         respond() {
-          let Mine = this.service('mine');
-          service = Mine;
-          return Mine;
+          let mock = this.service('mock');
+          service = mock;
+          return mock;
         }
       }
       let mock = mockReqRes();
+      class MockService extends Service {
+      }
 
-      mock.container.register('service:mine', { type: 'mine' });
+      mock.container.register('service:mock', MockService);
 
       let action = new TestAction(mock);
 
       return action.run().then(() => {
-        expect(service.type).to.eql('mine');
+        expect(service instanceof MockService).to.be.true();
       });
     });
 


### PR DESCRIPTION
Not sure if I'm missing something, but it didn't seem that this
was being done elsewhere, even though it was advertised as such in the API docs
and in the container tests.

Also fixes the autoLoadedExtensions not being added.

This allows it to work with the mailer.