### PR TITLE
fix(docs): finish documenting `Logger` class

### DIFF
--- a/lib/runtime/logger.js
+++ b/lib/runtime/logger.js
@@ -12,11 +12,29 @@ import padStart from 'lodash/padStart';
  * @submodule runtime
  */
 export default class Logger {
+  /**
+   * Default log level if none specified.
+   *
+   * @property logLevel
+   * @type {String}
+   */
+  loglevel = 'info';
 
-  loglevel = 'debug';
-
+  /**
+   * Specify if logs should be colorized.
+   *
+   * @property colorize
+   * @type {Boolean}
+   */
   colorize = true;
 
+  /**
+   * Available log levels that can be used.
+   *
+   * @property levels
+   * @type {Array}
+   * @private
+   */
   levels = [
     'debug',
     'info',
@@ -24,6 +42,13 @@ export default class Logger {
     'error'
   ];
 
+  /**
+   * Color map for the available levels.
+   *
+   * @property colors
+   * @type {Object}
+   * @private
+   */
   colors = {
     debug: chalk.cyan,
     info: chalk.white,
@@ -31,25 +56,60 @@ export default class Logger {
     error: chalk.red
   };
 
+  /**
+   * Log at the 'debug' level.
+   *
+   * @method debug
+   * @param msg {String} Message to log to the logger
+   */
   debug(msg) {
     this.log('debug', msg);
   }
 
+  /**
+   * Log at the 'info' level.
+   *
+   * @method info
+   * @param msg {String} Message to log to the logger
+   */
   info(msg) {
     this.log('info', msg);
   }
 
+  /**
+   * Log at the 'warn' level.
+   *
+   * @method warn
+   * @param msg {String} Message to log to the logger
+   */
   warn(msg) {
     this.log('warn', msg);
   }
 
+  /**
+   * Log at the 'error' level.
+   *
+   * @method error
+   * @param msg {String} Message to log to the logger
+   */
   error(msg) {
     this.log('error', msg);
   }
 
+  /**
+   * Log a message to the logger at a specific log level.
+   *
+   * @method log
+   * @param level {String} Level to log at
+   * @param msg {String} Message to log to the logger
+   */
   log(level, msg) {
+    if (!arguments.length === 1) {
+      msg = level;
+      level = this.logLevel;
+    }
     if (!this.levels.includes(level)) {
-      level = 'info';
+      level = this.logLevel;
     }
     let timestamp = (new Date()).toISOString();
     let padLength = this.levels.reduce((n, label) => Math.max(n, label.length));


### PR DESCRIPTION
Also makes use of the unused `logLevel` property while
also making `logger.log(msg)` a thing since it seems very natural.

Fixes #167 