### PR TITLE
docs(tests): add a note about how to run --filter

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,3 @@
+# Use npm run test -- (other args here) to pass args to mocha
 cd dist
 NODE_ENV=test nyc mocha --recursive "$@"


### PR DESCRIPTION
I got tripped up by the need to add `--` before the args I wanted to pass to Mocha, thought documenting this would save someone else some future grief ...