### PR TITLE
feat(data): Pass entire response object to serializer

### DIFF
--- a/lib/data/serializer.js
+++ b/lib/data/serializer.js
@@ -16,13 +16,12 @@ export default class Serializer {
   }
 
   /**
-   * Take the supplied payload of record(s) or error(s) and the supplied options
-   * and return a rendered a JSON response object.
+   * Take the supplied Response instance and the supplied options and return a
+   * rendered a JSON response object.
    *
    * @method serialize
-   * @param payload {Object[]|Error[]|Object|Error}
+   * @param response {Response}
    * @param options {Object}
-   * @return {Object} the JSON response object
    */
   static serialize() {
     throw new Error('You must implement the `serialize` method!');

--- a/lib/data/serializers/flat.js
+++ b/lib/data/serializers/flat.js
@@ -25,15 +25,14 @@ export default class FlatSerializer extends Serializer {
    * Renders the payload, either a primary data payload or an error payload.
    *
    * @method serialize
-   * @param payload {Object|Array} a record, array of records, or error
+   * @param payload {Response}
    * @param options {Object}
-   * @return {Object|Array} the rendered payload
    */
-  static serialize(payload, options = {}) {
-    if (payload instanceof Error) {
-      return this.renderError(payload);
+  static serialize(response, options = {}) {
+    if (response.body instanceof Error) {
+      response.body = this.renderError(response.body);
     }
-    return this.renderPrimary(payload, options);
+    response.body = this.renderPrimary(response.body, options);
   }
 
   /**

--- a/lib/data/serializers/json-api.js
+++ b/lib/data/serializers/json-api.js
@@ -34,23 +34,22 @@ function setIfNotEmpty(obj, key, value) {
 export default class JSONAPISerializer extends Serializer {
 
   /**
-   * Take a payload (a model, an array of models, or an Error) and render it as
-   * a JSONAPI compliant document
+   * Take a resposne body (a model, an array of models, or an Error) and render
+   * it as a JSONAPI compliant document
    *
    * @method serialize
-   * @param  {Object|Array|Error}   payload
-   * @param  {Object}               options
-   * @return {Object}         the rendered JSONAPI document
+   * @param  {Response}   response
+   * @param  {Object}     options
    */
-  static serialize(payload, options = {}) {
+  static serialize(response, options = {}) {
     let document = {};
-    this.renderPrimary(payload, document, options);
-    this.renderIncluded(payload, document, options);
-    this.renderMeta(payload, document, options);
-    this.renderLinks(payload, document, options);
-    this.renderVersion(payload, document, options);
+    this.renderPrimary(response.body, document, options);
+    this.renderIncluded(response.body, document, options);
+    this.renderMeta(response.body, document, options);
+    this.renderLinks(response.body, document, options);
+    this.renderVersion(response.body, document, options);
     this.dedupeIncluded(document);
-    return document;
+    response.body = document;
   }
 
   /**

--- a/lib/runtime/action.js
+++ b/lib/runtime/action.js
@@ -184,7 +184,7 @@ export default class Action {
         type = 'application';
       }
       let serializer = this.container.lookup(`serializer:${ type }`);
-      response.body = serializer.serialize(response.body, assign({ action: this }, response.options));
+      serializer.serialize(response, assign({ action: this }, response.options));
     }
 
     this._response.statusCode = response.status;


### PR DESCRIPTION
By passing the entire response object, and not just the body, to the serializer, it allows for additional scope of customization from the serializer. For example:

* The serializer now has access to the Response's `options` hash, so actions no longer need to resort to message passing to the serializer via injecting metadata into the response body just to have the serializer strip it out.
* The serializer can add headers, like an appropriate Content-Type header or Link header for pagination.

Note that this change means the `Serializer.serialize` method is now expect to work by mutating the passed in Response object, rather than returning a response body.