### PR TITLE
Set content type via serializer

### DIFF
--- a/lib/data/serializers/flat.js
+++ b/lib/data/serializers/flat.js
@@ -21,6 +21,8 @@ import {
 
 export default class FlatSerializer extends Serializer {
 
+  static contentType = 'application/json';
+
   /**
    * Renders the payload, either a primary data payload or an error payload.
    *
@@ -33,6 +35,7 @@ export default class FlatSerializer extends Serializer {
       response.body = this.renderError(response.body);
     }
     response.body = this.renderPrimary(response.body, options);
+    response.contentType = this.contentType;
   }
 
   /**

--- a/lib/data/serializers/json-api.js
+++ b/lib/data/serializers/json-api.js
@@ -33,6 +33,8 @@ function setIfNotEmpty(obj, key, value) {
 
 export default class JSONAPISerializer extends Serializer {
 
+  static contentType = 'application/vnd.api+json';
+
   /**
    * Take a resposne body (a model, an array of models, or an Error) and render
    * it as a JSONAPI compliant document
@@ -50,6 +52,7 @@ export default class JSONAPISerializer extends Serializer {
     this.renderVersion(response.body, document, options);
     this.dedupeIncluded(document);
     response.body = document;
+    response.contentType = this.contentType;
   }
 
   /**

--- a/lib/runtime/response.js
+++ b/lib/runtime/response.js
@@ -41,8 +41,10 @@ export default class Response {
    * @type {String}
    */
   get contentType() {
-    // TODO this default should be a config option
     return this.options.contentType || 'application/json';
+  }
+  set contentType(value) {
+    this.options.contentType = value;
   }
 
 }


### PR DESCRIPTION
This PR is based off #175, so it shouldn't be merged until that one is.

This leverages the new "pass the entire response to the serializer" to change the out-of-the-box serializers to set an appropriate Content-Type header on the response.