### PR TITLE
fix(cli): Give linting logs a bit more context

### DIFF
--- a/cli/lint-tree.js
+++ b/cli/lint-tree.js
@@ -27,20 +27,25 @@ export default class LintTree extends Filter {
   processString(content, relativePath) {
     let report = this.cli.executeOnText(content, path.join(this.rootDir, relativePath));
     let result = report.results[0] || {};
-    let errors = result.messages || [];
+    let messages = result.messages || [];
 
-    errors = errors.filter((error) => !IGNORED_FILE_MESSAGE_REGEXP.test(error.message));
+    messages = messages.filter((msg) => !IGNORED_FILE_MESSAGE_REGEXP.test(msg.message));
 
     if (this.generateTests) {
-      return this.testGenerator(relativePath, errors);
+      return this.testGenerator(relativePath, messages);
     }
 
-    errors.forEach((error) => {
-      ui.warn(dedent`
-        ${ error.source }
-        ${ error.message } (${ error.ruleId })
-      `);
-    });
+    if (messages.length > 0) {
+      ui.warn(`${ relativePath } has ${ result.errorCount } errors and ${ result.warningCount } warnings.`);
+
+      messages.forEach((error, index) => {
+        ui.warn(dedent`
+            ${ index + 1 }: ${ error.message } (${ error.ruleId }) at line ${ error.line }:${ error.column }
+          ${ error.source }
+        `);
+      });
+    }
+
     return content;
   }
 


### PR DESCRIPTION
Print the file and line:column in a grouped layout.

Before:
![screen shot 2016-10-25 at 11 28 58 am](https://cloud.githubusercontent.com/assets/34726/19693569/027e43c8-9aaa-11e6-874d-963e09d40785.png)

After:
![screen shot 2016-10-25 at 11 55 26 am](https://cloud.githubusercontent.com/assets/34726/19693559/f73bc9fe-9aa9-11e6-8db5-8af26fa14189.png)
