### PR TITLE
fix(cli): convert denali-build.js to vanilla syntax in blueprints

### DIFF
--- a/blueprints/addon/files/__name__/denali-build.js
+++ b/blueprints/addon/files/__name__/denali-build.js
@@ -1,4 +1,4 @@
-import { Builder } from 'denali';
+const Builder = require('denali').Builder;
 
-export default class <%= className %>Builder extends Builder {
+module.exports = class <%= className %>Builder extends Builder {
 }

--- a/blueprints/app/files/__name__/denali-build.js
+++ b/blueprints/app/files/__name__/denali-build.js
@@ -1,4 +1,4 @@
-import { Builder } from 'denali';
+const Builder = require('denali').Builder;
 
-export default class <%= className %>Builder extends Builder {
+module.exports = class <%= className %>Builder extends Builder {
 }


### PR DESCRIPTION
no issue
- because it is required before any transpilation actually occurs, the `denali-build.js` file must be in vanilla-js syntax.