### PR TITLE
Misc. ORM/Model fixes

### DIFF
--- a/config/initializers/define-orm-models.ts
+++ b/config/initializers/define-orm-models.ts
@@ -21,7 +21,7 @@ export default {
       if (!modelsGroupedByAdapter.has(Adapter)) {
         modelsGroupedByAdapter.set(Adapter, []);
       }
-      modelsGroupedByAdapter.get(Adapter).push(Model);
+      modelsGroupedByAdapter.get(Adapter).push(ModelClass);
     });
     let definitions: any[] = [];
     modelsGroupedByAdapter.forEach((modelsForThisAdapter: typeof Model[], Adapter: ORMAdapter): void => {

--- a/lib/runtime/container.ts
+++ b/lib/runtime/container.ts
@@ -189,6 +189,19 @@ export default class Container extends DenaliObject {
       moduleName: camelCase(modulePath)
     };
   }
+
+  /**
+   * For a given type, returns the names of all the available modules under that
+   * type. Primarily used for debugging purposes (i.e. to show available modules
+   * when a lookup of that type fails).
+   */
+  availableForType(type: string): string[] {
+    return Object.keys(this._registry).filter((key) => {
+      return key.split(':')[0] === type;
+    }).map((key) => {
+      return key.split(':')[1];
+    });
+  }
 }
 
 

--- a/test/unit/container-test.ts
+++ b/test/unit/container-test.ts
@@ -18,7 +18,7 @@ test('Container > #lookupAll(type) > returns an object with all the modules of t
   let container = new Container();
   container.register('foo:bar', { buzz: true });
   container.register('foo:buzz', { bat: true });
-  let type = container.lookupAll('foo');
+  let type = (<any> container.lookupAll('foo'));
   t.truthy(type.bar);
   t.true(type.bar.buzz);
   t.truthy(type.buzz);
@@ -45,6 +45,17 @@ test('Container > singletons > lazily instantiates singletons (i.e. on lookup)',
   }
   (<any>Class).singleton = true;
   container.register('foo:bar', Class);
+});
+
+test('Container > #availableForType() > returns all registered instances of a type', async (t) => {
+  let container = new Container();
+
+  container.register('foo:a', {a: true});
+  container.register('foo:b', {b: true});
+  container.register('foo:c', {c: true});
+  container.register('foo:d', {d: true});
+
+  t.deepEqual(container.availableForType('foo'), ['a', 'b', 'c', 'd']);
 });
 
 test.todo('Container > #lookupSerializer() > injects all serializer singletons into each serializer');


### PR DESCRIPTION
This PR does two things:

- adds back the availableForType method that is needed in the model class and was lost after the TS switch
- Passes the actual ModelClass in the define-orm-models initializer, instead of the base class

TODO:
- [x] add tests