### PR TITLE
fix(router) add missing urlFor method to router

### DIFF
--- a/lib/data/serializers/json-api.ts
+++ b/lib/data/serializers/json-api.ts
@@ -441,7 +441,7 @@ export default class JSONAPISerializer extends Serializer {
   protected linksForRecord(context: Context, record: Model): JsonApiLinks {
     let router: Router = this.container.lookup('router:main');
     let url = router.urlFor(`${ pluralize(record.type) }/show`, record);
-    return url ? { self: <string> url } : null;
+    return typeof url === 'string' ? { self: url } : null;
   }
 
   /**

--- a/lib/data/serializers/json-api.ts
+++ b/lib/data/serializers/json-api.ts
@@ -441,7 +441,7 @@ export default class JSONAPISerializer extends Serializer {
   protected linksForRecord(context: Context, record: Model): JsonApiLinks {
     let router: Router = this.container.lookup('router:main');
     let url = router.urlFor(`${ pluralize(record.type) }/show`, record);
-    return url ? { self: url } : null;
+    return url ? { self: <string> url } : null;
   }
 
   /**

--- a/lib/runtime/router.ts
+++ b/lib/runtime/router.ts
@@ -252,6 +252,28 @@ export default class Router extends DenaliObject implements RouterDSL {
   }
 
   /**
+   * Returns the URL for a given action. You can supply a params object which
+   * will be used to fill in the dynamic segements of the action's route (if
+   * any).
+   */
+  urlFor(action: string | Action, data: any): string | boolean {
+    if (typeof action === 'string') {
+      action = this.container.lookup(`action:${ action }`);
+    }
+    if (!action) {
+      return false;
+    }
+
+    let route: Route;
+    forEach(this.routes, (routes) => {
+      route = find(routes, { action: <Action> action });
+      return !route; // kill the iterator if we found the match
+    });
+
+    return route && route.reverse(data);
+  }
+
+  /**
    * Shorthand for `this.route('get', ...arguments)`
    *
    * @since 0.1.0

--- a/lib/runtime/router.ts
+++ b/lib/runtime/router.ts
@@ -266,7 +266,7 @@ export default class Router extends DenaliObject implements RouterDSL {
 
     let route: Route;
     forEach(this.routes, (routes) => {
-      route = find(routes, { action: <Action> action });
+      route = find(routes, { action: <Action>action });
       return !route; // kill the iterator if we found the match
     });
 

--- a/test/unit/router-test.ts
+++ b/test/unit/router-test.ts
@@ -63,3 +63,38 @@ test('Router > does not attempt to serialize when action.serializer = false', as
   req.write('{}');
   await router.handle(<any>req, <any>new MockResponse());
 });
+
+test('Router > #urlFor works with string argument', (t) => {
+  let container = new Container();
+  let logger = new Logger();
+
+  container.register('action:index', class TestAction extends Action {
+    serializer = false;
+    respond() {
+      // noop
+    }
+  });
+
+  let router = new Router({ container, logger });
+  router.get('/test/:id/', 'index');
+
+  t.is(router.urlFor('index', {id: 10}), '/test/10/', 'Router should return the correctly reversed url');
+});
+
+test('Router > #urlFor works with action argument', (t) => {
+  let container = new Container();
+  let logger = new Logger();
+
+  container.register('action:index', class TestAction extends Action {
+    serializer = false;
+    respond() {
+      // noop
+    }
+  });
+
+  let router = new Router({ container, logger });
+  router.get('/test/:id/', 'index');
+
+  let TestAction = container.lookup('action:index');
+  t.is(router.urlFor(TestAction, {id: 10}), '/test/10/', 'Router should return the correctly reversed url');
+});


### PR DESCRIPTION
This PR re-adds the router.urlFor method dropped in the TS refactor, as well as tests to prove that it works.

/cc @davewasmer I was getting typescript compile errors locally - tried fixing them several ways and couldn't figure out how - pushing this to see a) if tests work and b) get comments on how to fix the typescript warnings.