### PR TITLE
Drain server connections on app shutdown

### DIFF
--- a/lib/runtime/application.ts
+++ b/lib/runtime/application.ts
@@ -207,9 +207,9 @@ export default class Application extends Addon {
         server = http.createServer(handler).listen(port, resolve);
       }
       this.drainers.push(async function drainHttp() {
-        await new Promise((resolve) => {
-          server.close(resolve);
-          setTimeout(resolve, 60 * 1000);
+        await new Promise((resolveDrainer) => {
+          server.close(resolveDrainer);
+          setTimeout(resolveDrainer, 60 * 1000);
         })
       });
     });

--- a/lib/runtime/application.ts
+++ b/lib/runtime/application.ts
@@ -72,6 +72,8 @@ export default class Application extends Addon {
    */
   public container: Container;
 
+  protected drainers: (() => Promise<void>)[];
+
   constructor(options: ApplicationOptions) {
     if (!options.container) {
       options.container = new Container();
@@ -84,6 +86,7 @@ export default class Application extends Addon {
       options.container.register('logger:main', options.logger);
     }
     super(<AddonOptions>options);
+    this.drainers = [];
     this.container.register('application:main', this);
     this.router = this.container.lookup('router:main');
     this.logger = this.container.lookup('logger:main');
@@ -197,11 +200,18 @@ export default class Application extends Addon {
   private async createServer(port: number): Promise<void> {
     await new Promise((resolve) => {
       let handler = this.router.handle.bind(this.router);
+      let server: any;
       if (this.config.server.ssl) {
-        https.createServer(this.config.server.ssl, handler).listen(port, resolve);
+        server = https.createServer(this.config.server.ssl, handler).listen(port, resolve);
       } else {
-        http.createServer(handler).listen(port, resolve);
+        server = http.createServer(handler).listen(port, resolve);
       }
+      this.drainers.push(async function drainHttp() {
+        await new Promise((resolve) => {
+          server.close(resolve);
+          setTimeout(resolve, 60 * 1000);
+        })
+      });
     });
   }
 
@@ -226,6 +236,7 @@ export default class Application extends Addon {
    * @since 0.1.0
    */
   public async shutdown(): Promise<void> {
+    await all(this.drainers.map((drainer) => drainer()));
     await all(this.addons.map(async (addon) => {
       await addon.shutdown(this);
     }));


### PR DESCRIPTION
Fixes #263 .

Adds a protected `drainers` array to Application. This will allow us to add future draining blockers, i.e. for a websockets server. I don't see a strong use case for making this userland accessible - Denali will control the major network servers (http, https, http2, websockets). If users want something else, that seems like a likely candidate for an addon, which gets it's own chance to shutdown.