### PR TITLE
fix(descriptors): descriptor options should default to an empty object

### DIFF
--- a/lib/data/descriptors.ts
+++ b/lib/data/descriptors.ts
@@ -18,7 +18,7 @@ export class Descriptor {
   /**
    * Creates an instance of Descriptor.
    */
-  constructor(type: string, options?: any) {
+  constructor(type: string, options: any = {}) {
     this.type = type;
     this.options = options;
   }


### PR DESCRIPTION
no issue
- this means that model definition hooks don't have to check everywhere if an attribute or relationship's options are set before checking for individual option properties