### PR TITLE
fix(build): ensure denali works correctly as a child addon

### DIFF
--- a/denali-build.js
+++ b/denali-build.js
@@ -20,7 +20,7 @@ module.exports = class DenaliBuilder extends Builder {
       build() {
         return new Promise((resolve, reject) => {
           exec(path.join(dir, 'node_modules/.bin/tsc') + ' --outDir ' + this.outputPath, {
-            cwd: this.inputPaths[0],
+            cwd: dir,
             stdio: 'inherit'
           }, (err, stdout, stderr) => {
             if (err) {


### PR DESCRIPTION
no issue
- the typescript tree needs to run in the correct cwd to ensure that denali is built correctly