### PR TITLE
Add teardown hooks

### DIFF
--- a/lib/metal/container.ts
+++ b/lib/metal/container.ts
@@ -234,6 +234,7 @@ export default class Container {
     if (this.getOption(specifier, 'instantiate') === false) {
       let klass = (<any>factory).class;
       if (!singleton) {
+        this.lookups[specifier] = klass;
         return klass;
       }
       let instance = klass;
@@ -319,6 +320,17 @@ export default class Container {
     delete this.lookups[specifier];
     delete this.classLookups[specifier];
     delete this.factoryLookups[specifier];
+  }
+
+  /**
+   * Given container-managed singletons a chance to cleanup on application shutdown
+   */
+  teardown() {
+    forEach(this.lookups, (instance: DenaliObject, specifier) => {
+      if (typeof instance.teardown === 'function') {
+        instance.teardown();
+      }
+    });
   }
 
   /**

--- a/lib/metal/object.ts
+++ b/lib/metal/object.ts
@@ -36,4 +36,11 @@ export default class DenaliObject {
     // Default is no-op
   }
 
+  /**
+   * A hook invoked when an application is torn down. Only invoked on singletons stored in the container.
+   */
+  teardown(): void {
+    // Default is no-op
+  }
+
 }

--- a/lib/runtime/application.ts
+++ b/lib/runtime/application.ts
@@ -265,6 +265,7 @@ export default class Application extends Addon {
     await all(this.addons.map(async (addon) => {
       await addon.shutdown(this);
     }));
+    this.container.teardown();
   }
 
 }

--- a/test/unit/metal/container-test.ts
+++ b/test/unit/metal/container-test.ts
@@ -128,3 +128,15 @@ test('properties marked as injections are injected', async (t) => {
 
   t.true(foo.bar.isPresent, 'injection was applied');
 });
+
+test('tears down singletons', async (t) => {
+  t.plan(1);
+  let container = new Container(dummyAppPath);
+  container.register('foo:main', {
+    teardown() {
+      t.pass();
+    }
+  }, { singleton: false, instantiate: false });
+  container.lookup('foo:main');
+  container.teardown();
+});


### PR DESCRIPTION
See #351 

Adds teardown hook to Denali Object class, which is invoked by `container.teardown()` (which itself is invoked during `application.shutdown()`).

Note that teardown() only works for container-managed singletons. Regular instances won't be invoked, nor will non-container managed singletons.

cc @seawatts 