### PR TITLE
Render attributes relationships options

### DIFF
--- a/lib/render/serializer.ts
+++ b/lib/render/serializer.ts
@@ -2,6 +2,7 @@ import View from './view';
 import { ServerResponse } from 'http';
 import Action, { RenderOptions } from '../runtime/action';
 import Errors from '../runtime/errors';
+import result from '../utils/result';
 
 export interface RelationshipConfig {
   strategy?: 'embed' | 'id' | string;
@@ -31,6 +32,14 @@ export default abstract class Serializer extends View {
   protected abstract attributes: ((...args: any[]) => string[]) | string[];
 
   /**
+   * Convenience method to encapsulate standard attribute whitelist behavior - render options
+   * take precedence, then allow this.attributes to be a function or straight definition
+   */
+  protected attributesToSerialize(action: Action, options: RenderOptions) {
+    return options.attributes || result(this.attributes, action);
+  }
+
+  /**
    * An object with configuration on how to serialize relationships. Relationships that have no
    * configuration present are omitted from the final rendered payload.
    *
@@ -46,6 +55,14 @@ export default abstract class Serializer extends View {
    * What the embedded records or ids look like is up to each serializer to determine.
    */
   protected abstract relationships: ((...args: any[]) => RelationshipConfigs) | RelationshipConfigs;
+
+  /**
+   * Convenience method to encapsulate standard relationship whitelist behavior - render options
+   * take precedence, then allow this.relationships to be a function or straight definition
+   */
+  protected relationshipsToSerialize(action: Action, options: RenderOptions) {
+    return options.relationships || result(this.relationships, action);
+  }
 
   async render(action: Action, response: ServerResponse, body: any, options: RenderOptions): Promise<void> {
     response.setHeader('Content-type', this.contentType);

--- a/lib/runtime/action.ts
+++ b/lib/runtime/action.ts
@@ -22,6 +22,7 @@ import inject from '../metal/inject';
 import Serializer from '../render/serializer';
 import DatabaseService from '../data/database';
 import Logger from './logger';
+import { RelationshipConfigs } from '../render/serializer';
 
 const debug = createDebug('denali:action');
 
@@ -64,6 +65,14 @@ export interface RenderOptions {
    * another kind of object, it will fall back to the application serializer.
    */
   serializer?: string;
+  /**
+   * Override which attributes should be serialized.
+   */
+  attributes?: string[];
+  /**
+   * Override which relationships should be serialized.
+   */
+  relationships?: RelationshipConfigs;
 }
 
 /**


### PR DESCRIPTION
Fixes #347

Allows:

```
this.render(post, { attributes: [ 'title' ] });
```

Which will override the serializer's class-defined attributes whitelist.