### PR TITLE
Make options optional on resource route

### DIFF
--- a/lib/runtime/router.ts
+++ b/lib/runtime/router.ts
@@ -59,7 +59,7 @@ export interface RouterDSL {
   delete(pattern: string, action: string, params: {}): void;
   head(pattern: string, action: string, params: {}): void;
   options(pattern: string, action: string, params: {}): void;
-  resource(resourceName: string, options: ResourceOptions): void;
+  resource(resourceName: string, options?: ResourceOptions): void;
 }
 
 /**


### PR DESCRIPTION
This fixes an issue where if you have a namespaced router typescript tries to make you require the options param.