### PR TITLE
Update logger with the ability to pass in ...params

### DIFF
--- a/lib/runtime/logger.ts
+++ b/lib/runtime/logger.ts
@@ -100,7 +100,7 @@ export default class Logger extends DenaliObject {
     }
   }
 
-  formatMessage(level: LogLevel, ...params: any[]): string {
+  protected formatMessage(level: LogLevel, ...params: any[]): string {
     let formattedMessage = util.format.apply(this, params);
 
     if (this.levels.indexOf(level) === -1) {
@@ -120,11 +120,11 @@ export default class Logger extends DenaliObject {
     return `[${timestamp}] ${levelLabel} - ${formattedMessage}\n`;
   }
 
-  write(message: string) {
+  protected write(message: string) {
     process.stdout.write(message);
   }
 
-  writeError(message: string) {
+  protected writeError(message: string) {
     process.stderr.write(message);
   }
 }


### PR DESCRIPTION
This emulates console.log https://developer.mozilla.org/en-US/docs/Web/API/Console/log
This also adds three new functions that can be overridden by the end user.
`formatMessage`
`write`
`writeError`

Instead of using console.log we are now using process.stdout | stderr correctly.

Also add new debug command to logger
Closes: https://github.com/denali-js/denali/issues/316