### PR TITLE
Add config service

### DIFF
--- a/app/services/config.ts
+++ b/app/services/config.ts
@@ -1,0 +1,1 @@
+export { default } from '../../lib/runtime/config';

--- a/lib/runtime/application.ts
+++ b/lib/runtime/application.ts
@@ -13,6 +13,7 @@ import Addon from './addon';
 import topsort from '../utils/topsort';
 import Router from './router';
 import Logger from './logger';
+import { AppConfig } from './config';
 import Container from '../metal/container';
 import findPlugins from 'find-plugins';
 import * as tryRequire from 'try-require';
@@ -21,77 +22,12 @@ import { Vertex } from '../utils/topsort';
 
 const debug = createDebug('denali:application');
 
-export interface Config {
-  /**
-   * THe name of the current environment, i.e. 'developement', 'test', 'production'
-   */
-  environment: string;
-  logging?: {
-    /**
-     * Should logs show debug information? If true, errors will log out as much detail as possible.
-     */
-    showDebuggingInfo?: boolean;
-    /**
-     * A morgan log format string to use
-     */
-    format?: string;
-    /**
-     * A function to determine whether or not logging should be skipped for a given request - see
-     * morgan docs for details
-     */
-    skip?(): boolean;
-  };
-  /**
-   * Cookie parser configuration - see cookie-parser for details
-   */
-  cookies?: any;
-  /**
-   * CORS configuration - see cors middleware package for details
-   */
-  cors?: any;
-  bodyParser?: {
-    /**
-     * What content-types should the body parser try to parse as JSON?
-     */
-    type?: string;
-  };
-  migrations?: {
-    /**
-     * Knex configuration information for running migrations
-     */
-    db?: any;
-  }
-  server: {
-    /**
-     * THe port number that the application should start up on
-     */
-    port: number;
-    /**
-     * Should the application start in detached mode? I.e. without attaching to a port?
-     */
-    detached?: boolean;
-    /**
-     * SSL/TLS certificate files. Note these should be the file contents, not the file paths
-     */
-    ssl?: {
-      key: Buffer | string;
-      cert: Buffer | string;
-    }
-  },
-  /**
-   * Connection and configuration for your ORM adapter - see your ORM adapter docs for
-   * details
-   */
-  database?: any;
-  [key: string]: any;
-}
-
 export interface AppConfigBuilder {
-  (environment: string, container: Container): Config;
+  (environment: string, container: Container): AppConfig;
 }
 
 export interface AddonConfigBuilder {
-  (environment: string, container: Container, config: any): void;
+  (environment: string, container: Container, config: AppConfig): void;
 }
 
 export interface MiddlewareBuilder {

--- a/lib/runtime/config.ts
+++ b/lib/runtime/config.ts
@@ -1,0 +1,122 @@
+import Service from './service';
+import inject from '../metal/inject';
+import { get } from 'lodash';
+
+export default class ConfigService extends Service {
+
+  protected _config = inject<AppConfig>('config:environment');
+
+  get environment(): string {
+    return this._config.environment;
+  }
+
+
+  get<S extends AppConfig, T1 extends keyof S>(p1: T1): S[T1];
+  get<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1]>(p1: T1, p2: T2): S[T1][T2];
+  get<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2]>(p1: T1, p2: T2, p3: T3): S[T1][T2][T3];
+  get<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3]>(p1: T1, p2: T2, p3: T3, p4: T4): S[T1][T2][T3][T4];
+  get<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3], T5 extends keyof S[T1][T2][T3][T4]>(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5): S[T1][T2][T3][T4][T5];
+  get<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3], T5 extends keyof S[T1][T2][T3][T4], T6 extends keyof S[T1][T2][T3][T4][T5]>(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6): S[T1][T2][T3][T4][T5][T6];
+  get<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3], T5 extends keyof S[T1][T2][T3][T4], T6 extends keyof S[T1][T2][T3][T4][T5], T7 extends keyof S[T1][T2][T3][T4][T5][T6]>(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7): S[T1][T2][T3][T4][T5][T6][T7];
+  get(...path: string[]): any {
+    // Split on dots in path segments, allowing for `get('foo.bar')` as well as `get('foo', 'bar')`
+    path = path.reduce((segments, nextSegment) => segments.concat(nextSegment.split('.')), []);
+    return get(this._config, path);
+  }
+
+  getWithDefault<S extends AppConfig, T1 extends keyof S>(p1: T1, defaultValue: any): S[T1];
+  getWithDefault<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1]>(p1: T1, p2: T2, defaultValue: any): S[T1][T2];
+  getWithDefault<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2]>(p1: T1, p2: T2, p3: T3, defaultValue: any): S[T1][T2][T3];
+  getWithDefault<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3]>(p1: T1, p2: T2, p3: T3, p4: T4, defaultValue: any): S[T1][T2][T3][T4];
+  getWithDefault<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3], T5 extends keyof S[T1][T2][T3][T4]>(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, defaultValue: any): S[T1][T2][T3][T4][T5];
+  getWithDefault<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3], T5 extends keyof S[T1][T2][T3][T4], T6 extends keyof S[T1][T2][T3][T4][T5]>(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, defaultValue: any): S[T1][T2][T3][T4][T5][T6];
+  getWithDefault<S extends AppConfig, T1 extends keyof S, T2 extends keyof S[T1], T3 extends keyof S[T1][T2], T4 extends keyof S[T1][T2][T3], T5 extends keyof S[T1][T2][T3][T4], T6 extends keyof S[T1][T2][T3][T4][T5], T7 extends keyof S[T1][T2][T3][T4][T5][T6]>(p1: T1, p2: T2, p3: T3, p4: T4, p5: T5, p6: T6, p7: T7, defaultValue: any): S[T1][T2][T3][T4][T5][T6][T7];
+  getWithDefault(...args: any[]): any {
+    let defaultValue = args.pop();
+    let path = <string[]>args;
+    // Split on dots in path segments, allowing for `get('foo.bar')` as well as `get('foo', 'bar')`
+    path = path.reduce((segments, nextSegment) => segments.concat(nextSegment.split('.')), []);
+    return get(this._config, path, defaultValue);
+  }
+
+}
+
+export interface AppConfig {
+  /**
+   * The name of the current environment, i.e. 'developement', 'test', 'production'
+   */
+  environment: string;
+
+  logging?: {
+
+    /**
+     * Should logs show debug information? If true, errors will log out as much detail as possible.
+     */
+    showDebuggingInfo?: boolean;
+
+    /**
+     * A morgan log format string to use
+     */
+    format?: string;
+
+    /**
+     * A function to determine whether or not logging should be skipped for a given request - see
+     * morgan docs for details
+     */
+    skip?(): boolean;
+
+  };
+
+  /**
+   * Cookie parser configuration - see cookie-parser for details
+   */
+  cookies?: any;
+
+  /**
+   * CORS configuration - see cors middleware package for details
+   */
+  cors?: any;
+
+  migrations?: {
+
+    /**
+     * Knex configuration information for running migrations
+     */
+    db?: any;
+
+  };
+
+  server: {
+
+    /**
+     * THe port number that the application should start up on
+     */
+    port: number;
+
+    /**
+     * Should the application start in detached mode? I.e. without attaching to a port?
+     */
+    detached?: boolean;
+
+    /**
+     * SSL/TLS certificate files. Note these should be the file contents, not the file paths
+     */
+    ssl?: {
+      key: Buffer | string;
+      cert: Buffer | string;
+    }
+
+    trustProxy?: string | string[] | ((addr?: string, i?: number) => boolean);
+
+    subdomainOffset?: number;
+
+  };
+
+  /**
+   * Connection and configuration for your ORM adapter - see your ORM adapter docs for
+   * details
+   */
+  database?: any;
+
+  [key: string]: any;
+}


### PR DESCRIPTION
The config service does three things:

1. Provides for a slightly simpler import/injection experience vs `inject('config:environment');`
2. Provides a safe way of attempting to access deep properties whose intermediate objects may not exist, without needing a ton of null checks. Also makes default config values easier via `getWithDefault`
4. Provides type safety for known config values, if the consuming TS code uses the `config.get('one', 'two')` syntax rather than dot notation