### PR TITLE
Fix issue with error template

### DIFF
--- a/app/views/error.html.ts
+++ b/app/views/error.html.ts
@@ -48,7 +48,7 @@ let template = compileTemplate(`
           <h2 class='source'>from <%= data.error.action %></h2>
         <% } %>
         <h5>Stacktrace:</h5>
-        <pre><code><%= data.error.stack.replace('\\n', '\n') %></code></pre>
+        <pre><code><%= data.error.stack %></code></pre>
       </div>
     </body>
   </html>
@@ -60,6 +60,7 @@ export default class ErrorView extends View {
 
   async render(action: Action, response: ServerResponse, error: any, options: RenderOptions) {
     response.setHeader('Content-type', 'text/html');
+    error.stack = error.stack.replace('\\n', '\n');
     response.write(template({ error }));
     response.end();
   }

--- a/test/unit/render/view-test.ts
+++ b/test/unit/render/view-test.ts
@@ -1,0 +1,20 @@
+/* tslint:disable:completed-docs no-empty no-invalid-this member-access */
+import test from 'ava';
+// import ErrorView from '../../../app/views/error.html';
+import { /*Container,*/ MockResponse } from 'denali';
+
+test.beforeEach(async (t) => {
+  // let container = t.context.container = new Container(__dirname);
+  // t.context.view = new ErrorView(container);
+});
+
+test.skip('it renders the error view correctly', (t) => {
+  let response = new MockResponse();
+  let error = new Error();
+  response.write = () => {
+    t.pass();
+    return true;
+  };
+
+  t.context.view.render(null, response, error, {});
+});


### PR DESCRIPTION
Cannot use `\\` in template
https://lodash.com/docs/4.17.4#template
https://github.com/lodash/lodash/blob/4.17.4/lodash.js#L170