### PR TITLE
fix resolver order

### DIFF
--- a/lib/metal/container.ts
+++ b/lib/metal/container.ts
@@ -245,7 +245,7 @@ export class Container {
     let registrations = Object.keys(this.registry).filter((specifier) => {
       return specifier.startsWith(type);
     });
-    let resolved = this.resolvers.reverse().reduce((entries, resolver) => {
+    let resolved = [...this.resolvers].reverse().reduce((entries, resolver) => {
       return entries.concat(resolver.availableForType(type));
     }, []);
     return uniq(registrations.concat(resolved)).map((specifier) => specifier.split(':')[1]);

--- a/test/unit/metal/container-test.ts
+++ b/test/unit/metal/container-test.ts
@@ -82,4 +82,22 @@ test('availableForType() returns all registered instances of a type', async (t) 
   t.deepEqual(container.availableForType('foo'), ['a', 'b', 'c', 'd']);
 });
 
+test('the resolver order should not be changed by lookup methods', async (t) => {
+  const container: Container = t.context.subject();
+
+  const loaderMock = (name : string) => ({
+    retrieve: () => name,
+    loadRelative: () => name,
+    factories: new Map(),
+  }) as any;
+
+  container.loadBundleScope(loaderMock('l1'));
+  container.loadBundleScope(loaderMock('l2'));
+
+  t.deepEqual(container.lookup('foo:l1', { raw: true }), 'l1');
+  container.availableForType('foo');
+  t.deepEqual(container.lookup('foo:l1', { raw: true }), 'l1');
+  t.deepEqual(container.lookup('foo:l1', { raw: true }), 'l1');
+});
+
 test.todo('fallsback to `fallbacks` specifiers if original specifier is not found');


### PR DESCRIPTION
Fix wrong used .reverse() in availableForType


beware: **`.reverse()` does modify the original array**! This can be prevented by creating a new array with `[...arr]`.

Fixes #432